### PR TITLE
Errors: add format to pwa route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest, defaults: { format: :json }
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   root to: "welcome#index"


### PR DESCRIPTION
**Why**

We got an error when somebody hit `/manifest` without a format. Probably
a crawler or something, but might as well direct them to the correct
resource.
