### PR TITLE
Music: add note utils, pitch detector, and reference player

### DIFF
--- a/.eslint_todo.ts
+++ b/.eslint_todo.ts
@@ -28,6 +28,7 @@ const config: Linter.Config[] = [
   {
     files: [
       "spec/javascript/helpers/assert_spec.ts",
+      "spec/javascript/music/note_utils_spec.ts",
     ],
     rules: {
       "vitest/prefer-describe-function-title": "off",
@@ -37,6 +38,8 @@ const config: Linter.Config[] = [
   {
     files: [
       "app/javascript/controllers/hotkeys_controller.ts",
+      "app/javascript/music/note_utils.ts",
+      "app/javascript/music/pitch_detector.ts",
       "spec/javascript/application_spec.ts",
       "spec/javascript/channels/consumer_spec.ts",
       "spec/javascript/controllers/deck_type_controller_spec.ts",
@@ -45,6 +48,8 @@ const config: Linter.Config[] = [
       "spec/javascript/controllers/hotkeys_controller_spec.ts",
       "spec/javascript/controllers/mobile_nav_controller_spec.ts",
       "spec/javascript/helpers/assert_spec.ts",
+      "spec/javascript/music/pitch_detector_spec.ts",
+      "spec/javascript/music/reference_player_spec.ts",
       "spec/javascript/setup.ts",
       "spec/javascript/support/stimulus.ts",
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,9 +210,15 @@ end
 
 **Core Models:**
 - `User` - Authentication, has many decks. Has `username` (unique, alphanumeric + underscores)
-- `Deck` - Collection of flashcards, belongs to user. Has `visibility` (`"public"` or `"private"`, default `"private"`). Public decks appear in the catalog. Has `level` (integer, default 1 via application, no DB default) representing the current study level.
-- `Card` - Individual flashcard with front/back, belongs to deck
+- `Deck` (STI base) - Collection of flashcards, belongs to user. Has `visibility` (`"public"`, `"private"`, `"demo"`), `level` (default 1, current study level), `distractor_pool` (`"category"`, `"preset"`, or `"none"`).
+- `Card` (STI base) - Individual flashcard, belongs to deck
 - `Subscription` - Payment/subscription info, belongs to user
+
+**STI subclasses:**
+- `TextDeck < Deck` / `TextCard < Card` — the original "question/answer" flashcard flow with multiple-choice study. Validates `back` and `category` presence.
+- `MusicDeck < Deck` / `MusicCard < Card` — microphone-driven music study. `MusicCard` validates `back` against `MusicCard::SEQUENCE_REGEXP` (note sequences like `E3` or `C4,E4,G4`). `MusicDeck` defaults `distractor_pool` to `"none"`.
+
+**STI convention — `model_name` override:** every Deck/Card subclass overrides `self.model_name` to return the parent's so `form_with(model: text_deck)` keeps routing to `decks_path` (not `text_decks_path`). Apply this to any new STI subclass.
 
 **Card Progress:**
 - A card is "done" at the current level when `correct_streak >= deck.level`
@@ -256,38 +262,47 @@ Uses **Creem** (creem.io) for subscription payments:
 app/
 ├── actions/             # Service objects for complex operations
 │   ├── catalog/
-│   │   └── copy_deck.rb  # Duplicates a public deck into a user's account
+│   │   └── copy_deck.rb     # Duplicates a public deck into a user's account
+│   ├── decks/
+│   │   ├── create.rb        # Text deck CSV import
+│   │   └── create_music.rb  # Music deck CSV import (note-sequence backs)
 │   └── creem/
 │       ├── cancel_subscription.rb
 │       └── client.rb
 ├── components/
-│   └── base.rb           # Base component with Rails helpers
+│   ├── base.rb                    # Base component (supporter_badge, music_badge helpers)
+│   └── music_csv_instructions.rb  # CSV format help block for music decks
 ├── domain/
-│   └── study.rb          # Study engine: card selection, answer processing, level advancement
+│   ├── study.rb         # Study engine; `Study.for(deck:)` dispatches by deck type
+│   └── music_study.rb   # MusicStudy < Study; overrides `possible_answers` to []
 ├── controllers/
 │   ├── application_controller.rb
 │   ├── cards_controller.rb
 │   ├── catalog_controller.rb
-│   ├── decks_controller.rb
+│   ├── decks_controller.rb     # `#create` dispatches Decks::Create vs Decks::CreateMusic on :deck_type
 │   ├── pages_controller.rb
 │   └── subscriptions_controller.rb
 ├── models/
 │   ├── user.rb
-│   ├── deck.rb
-│   ├── card.rb
+│   ├── deck.rb          # STI base
+│   ├── text_deck.rb     # STI subclass — overrides model_name
+│   ├── music_deck.rb    # STI subclass — defaults distractor_pool to "none"
+│   ├── card.rb          # STI base
+│   ├── text_card.rb     # STI subclass — validates back + category presence
+│   ├── music_card.rb    # STI subclass — validates back against SEQUENCE_REGEXP
 │   └── subscription.rb
 ├── views/
 │   ├── base.rb           # Base view class
 │   ├── layouts/
 │   │   └── application.rb
 │   ├── catalog/
-│   │   ├── index.rb      # Public deck grid
-│   │   └── show.rb       # Deck preview + copy action
+│   │   ├── index.rb      # Public deck grid (mic badge for music decks)
+│   │   └── show.rb       # Deck preview + copy action (mic badge in header)
 │   ├── welcome/
 │   │   └── index.rb
 │   ├── decks/
 │   │   ├── index.rb
-│   │   ├── new.rb
+│   │   ├── new.rb        # Includes deck-type toggle (text vs music)
 │   │   └── show.rb
 │   ├── pages/
 │   │   ├── privacy.rb
@@ -299,6 +314,17 @@ app/
 │   │   └── update.rb
 │   └── subscriptions/
 │       └── show.rb
+├── javascript/
+│   ├── controllers/
+│   │   ├── deck_type_controller.ts  # Toggles CSV instructions block on creation form
+│   │   ├── dialog_controller.ts
+│   │   ├── file_upload_controller.ts
+│   │   ├── hotkeys_controller.ts
+│   │   └── mobile_nav_controller.ts
+│   └── music/
+│       ├── note_utils.ts        # Note ↔ frequency, sequence parsing
+│       ├── pitch_detector.ts    # YIN-style pitch detection from Float32Array samples
+│       └── reference_player.ts  # Web Audio sine playback for note sequences
 └── assets/
     └── stylesheets/
         ├── application.css
@@ -309,6 +335,10 @@ app/
         ├── layout.css
         ├── welcome.css
         └── decks.css
+
+db/
+└── seeds/
+    └── music_decks.rb   # Seeds starter music decks (called from db/seeds.rb)
 ```
 
 ### Actions
@@ -476,10 +506,37 @@ Users can browse and copy public decks at `/catalog`:
 
 ### CSV Import
 
-Decks are created by uploading CSV files with this format:
-- Columns: `front`, `back`, `category`
+Decks are created by uploading CSV files. The deck-creation form has a "Deck Type" toggle (text vs music) that picks the importer.
+
+**Text decks (`Decks::Create`):**
+- Columns: `front`, `back`, `category` (`distractors` optional)
 - Multiple answers separated by `;`
 - Sample CSV available via environment variable `SAMPLE_CSV_URL`
+
+**Music decks (`Decks::CreateMusic`):** see Music Decks section below.
+
+### Music Decks
+
+Microphone-driven music study (target: guitar / ukulele). Public music decks appear in the catalog with a 🎤 badge (rendered via `Components::Base#music_badge`).
+
+**Card data model:**
+- `front` = label, **hidden during attempt**, revealed on success (e.g. `"C Major Chord"`)
+- `back` = comma-separated note sequence — both played as the audio reference and what the user must play back (e.g. `"C4,E4,G4"`). Validated against `MusicCard::SEQUENCE_REGEXP` (sharps only, octaves 1–8).
+
+**CSV format:** same headers as text decks (`front,back,category`). Multi-note backs **must be quoted** (`"C4,E4,G4"`) so commas don't split the cell. Music CSVs reject space-separated notes — the format is one canonical comma-only shape.
+
+**Domain dispatch:** `Study.for(deck:)` returns `MusicStudy` for music decks (overrides `possible_answers` to `[]`). The base `Study#answer_card` works for music as-is — the JS POSTs `answer = card.back` so the existing `card.back == answer` comparison is the right check.
+
+**Study UI:** the in-browser music-study experience (mic capture, sequence state machine, Phlex view) is on its own track and not yet shipped. Currently `StudiesController` renders the text study view for all deck types; music decks exist in the catalog and creation flow but the play experience for them is not wired up yet.
+
+**JS modules** (under `app/javascript/music/`) — pure, framework-free, 100% Vitest coverage:
+- `note_utils.ts` — `noteToFrequency("A4") → 440`, `frequencyToNote(440) → {note: "A4", cents: 0}`, `parseSequence("C4,E4,G4") → ["C4", "E4", "G4"]`. Equal-temperament from MIDI; sharps only, no flats.
+- `pitch_detector.ts` — `detectPitch(samples, sampleRate, options?) → Hz | null`. Simplified YIN (cumulative-mean-normalized difference function + first-below-threshold + local-min walk). No parabolic interpolation — accuracy is sufficient for the ±50¢ tolerance, and skipping it keeps branch coverage tractable. Defaults: threshold 0.15, search range 60–2000 Hz.
+- `reference_player.ts` — `playSequence(ctx, notes, options?) → Promise<void>`. Schedules sine oscillators on an injected `AudioContextLike` (narrow structural interface so jsdom mocks satisfy the type without `as` casts). Defaults: 500ms note + 100ms gap.
+
+**Mic & audio constraints (for the upcoming Stimulus integration):**
+- `getUserMedia` and `AudioContext` require HTTPS. Rails dev (`bin/dev`) defaults to plain HTTP — use a self-signed cert or staging.
+- `AudioContext` autoplay policy: create/resume inside a user-gesture handler, never on page load.
 
 ### Study Algorithm
 

--- a/app/javascript/music/note_utils.ts
+++ b/app/javascript/music/note_utils.ts
@@ -1,0 +1,68 @@
+import {assert} from "helpers/assert";
+
+const A4_FREQUENCY = 440;
+const A4_MIDI = 69;
+const SEMITONES_PER_OCTAVE = 12;
+const CENTS_PER_SEMITONE = 100;
+
+const LETTER_TO_OFFSET: {[letter: string]: number} = {
+  /* eslint-disable id-length */
+  A: 9, B: 11, C: 0, D: 2, E: 4, F: 5, G: 7,
+  /* eslint-enable id-length */
+};
+
+const NOTE_NAMES = "C C# D D# E F F# G G# A A# B".split(" ");
+
+// eslint-disable-next-line prefer-named-capture-group
+const NOTE_REGEXP = /^([A-G])(#?)(\d)$/u;
+
+interface PitchMatch {
+  cents: number;
+  note: string;
+}
+
+function noteToMidi(note: string): number {
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+  const match = note.match(NOTE_REGEXP);
+  if (!match) {
+    throw new Error(`Invalid note: ${note}`);
+  }
+  const offset = assert(LETTER_TO_OFFSET[assert(match[1])]);
+  let sharpStep = 0;
+  if (match[2] === "#") {
+    sharpStep = 1;
+  }
+  const octave = Number(assert(match[3]));
+
+  return offset + sharpStep + (octave + 1) * SEMITONES_PER_OCTAVE;
+}
+
+function midiToNote(midi: number): string {
+  const octave = Math.floor(midi / SEMITONES_PER_OCTAVE) - 1;
+  const name = assert(NOTE_NAMES[midi % SEMITONES_PER_OCTAVE]);
+
+  return `${name}${octave}`;
+}
+
+function noteToFrequency(note: string): number {
+  const semitonesAboveA4 = noteToMidi(note) - A4_MIDI;
+
+  return A4_FREQUENCY * 2 ** (semitonesAboveA4 / SEMITONES_PER_OCTAVE);
+}
+
+function frequencyToNote(hz: number): PitchMatch {
+  const offsetSemitones =
+    SEMITONES_PER_OCTAVE * Math.log2(hz / A4_FREQUENCY);
+  const midi = A4_MIDI + offsetSemitones;
+  const rounded = Math.round(midi);
+  const cents = Math.round((midi - rounded) * CENTS_PER_SEMITONE);
+
+  return {cents, note: midiToNote(rounded)};
+}
+
+function parseSequence(text: string): string[] {
+  return text.split(",");
+}
+
+export {frequencyToNote, noteToFrequency, parseSequence};
+export type {PitchMatch};

--- a/app/javascript/music/pitch_detector.ts
+++ b/app/javascript/music/pitch_detector.ts
@@ -1,0 +1,104 @@
+import {assert} from "helpers/assert";
+
+const DEFAULT_THRESHOLD = 0.15;
+const DEFAULT_MIN_HZ = 60;
+const DEFAULT_MAX_HZ = 2000;
+const MIN_TAU = 2;
+
+interface DetectOptions {
+  maxHz?: number;
+  minHz?: number;
+  threshold?: number;
+}
+
+function differenceFunction(
+  samples: Float32Array,
+  maxTau: number,
+): Float32Array {
+  const diffs = new Float32Array(maxTau + 1);
+  for (let tau = 1; tau <= maxTau; tau += 1) {
+    let sum = 0;
+    for (let index = 0; index < maxTau; index += 1) {
+      const delta = assert(samples[index]) - assert(samples[index + tau]);
+      sum += delta * delta;
+    }
+    diffs[tau] = sum;
+  }
+
+  return diffs;
+}
+
+function normalizeCMNDF(diffs: Float32Array): void {
+  diffs[0] = 1;
+  let runningSum = 0;
+  for (let tau = 1; tau < diffs.length; tau += 1) {
+    runningSum += assert(diffs[tau]);
+    diffs[tau] = assert(diffs[tau]) * tau / runningSum;
+  }
+}
+
+interface SearchArgs {
+  diffs: Float32Array;
+  maxTau: number;
+  minTau: number;
+  threshold: number;
+}
+
+function findFundamentalTau(args: SearchArgs): number | null {
+  const {diffs, maxTau, minTau, threshold} = args;
+  for (let tau = minTau; tau <= maxTau; tau += 1) {
+    if (assert(diffs[tau]) < threshold) {
+      let bestTau = tau;
+      while (
+        bestTau < maxTau &&
+        assert(diffs[bestTau + 1]) < assert(diffs[bestTau])
+      ) {
+        bestTau += 1;
+      }
+
+      return bestTau;
+    }
+  }
+
+  return null;
+}
+
+interface ResolvedOptions {
+  maxTau: number;
+  minTau: number;
+  threshold: number;
+}
+
+function resolveOptions(
+  sampleRate: number,
+  options: DetectOptions,
+): ResolvedOptions {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  const minHz = options.minHz ?? DEFAULT_MIN_HZ;
+  const maxHz = options.maxHz ?? DEFAULT_MAX_HZ;
+  const minTau = Math.max(MIN_TAU, Math.floor(sampleRate / maxHz));
+  const maxTau = Math.floor(sampleRate / minHz);
+
+  return {maxTau, minTau, threshold};
+}
+
+function detectPitch(
+  samples: Float32Array,
+  sampleRate: number,
+  options: DetectOptions = {},
+): number | null {
+  const {maxTau, minTau, threshold} = resolveOptions(sampleRate, options);
+  if (samples.length < maxTau * 2) {
+    return null;
+  }
+  const diffs = differenceFunction(samples, maxTau);
+  normalizeCMNDF(diffs);
+  const tau = findFundamentalTau({diffs, maxTau, minTau, threshold});
+  if (tau === null) {
+    return null;
+  }
+
+  return sampleRate / tau;
+}
+
+export {detectPitch};

--- a/app/javascript/music/reference_player.ts
+++ b/app/javascript/music/reference_player.ts
@@ -1,0 +1,84 @@
+import {noteToFrequency} from "music/note_utils";
+
+const DEFAULT_NOTE_DURATION_MS = 500;
+const DEFAULT_GAP_MS = 100;
+const NOTE_VOLUME = 0.3;
+const MS_PER_SECOND = 1000;
+
+interface AudioParamLike {
+  setValueAtTime: (value: number, when: number) => void;
+}
+
+interface GainNodeLike {
+  connect: (dest: unknown) => void;
+  gain: AudioParamLike;
+}
+
+interface OscillatorLike {
+  connect: (dest: unknown) => void;
+  frequency: {value: number};
+  start: (when: number) => void;
+  stop: (when: number) => void;
+  type: OscillatorType;
+}
+
+interface AudioContextLike {
+  createGain: () => GainNodeLike;
+  createOscillator: () => OscillatorLike;
+  currentTime: number;
+  destination: unknown;
+}
+
+interface PlayOptions {
+  gapMs?: number;
+  noteDurationMs?: number;
+}
+
+interface ScheduleArgs {
+  ctx: AudioContextLike;
+  durationSec: number;
+  hz: number;
+  when: number;
+}
+
+function scheduleNote(args: ScheduleArgs): void {
+  const {ctx, durationSec, hz, when} = args;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = "sine";
+  osc.frequency.value = hz;
+  gain.gain.setValueAtTime(NOTE_VOLUME, when);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(when);
+  osc.stop(when + durationSec);
+}
+
+async function playSequence(
+  ctx: AudioContextLike,
+  notes: string[],
+  options: PlayOptions = {},
+): Promise<void> {
+  const noteDurationMs = options.noteDurationMs ?? DEFAULT_NOTE_DURATION_MS;
+  const gapMs = options.gapMs ?? DEFAULT_GAP_MS;
+  const noteSec = noteDurationMs / MS_PER_SECOND;
+  const gapSec = gapMs / MS_PER_SECOND;
+  const stepSec = noteSec + gapSec;
+
+  notes.forEach((note, index) => {
+    scheduleNote({
+      ctx,
+      durationSec: noteSec,
+      hz: noteToFrequency(note),
+      when: ctx.currentTime + index * stepSec,
+    });
+  });
+
+  const totalMs = notes.length * (noteDurationMs + gapMs);
+  await new Promise((resolve) => {
+    setTimeout(resolve, totalMs);
+  });
+}
+
+export {playSequence};
+export type {AudioContextLike};

--- a/spec/javascript/music/note_utils_spec.ts
+++ b/spec/javascript/music/note_utils_spec.ts
@@ -1,0 +1,103 @@
+import {describe, expect, it} from "vitest";
+import {
+  frequencyToNote,
+  noteToFrequency,
+  parseSequence,
+} from "music/note_utils";
+
+describe("noteToFrequency", () => {
+  it("returns 440 for A4", () => {
+    expect(noteToFrequency("A4")).toBeCloseTo(440, 5);
+  });
+
+  it("returns ~261.63 for C4 (middle C)", () => {
+    expect(noteToFrequency("C4")).toBeCloseTo(261.63, 1);
+  });
+
+  it("returns ~277.18 for C#4", () => {
+    expect(noteToFrequency("C#4")).toBeCloseTo(277.18, 1);
+  });
+
+  it("doubles the frequency one octave up", () => {
+    expect(noteToFrequency("A5")).toBeCloseTo(880, 5);
+  });
+
+  it("halves the frequency one octave down", () => {
+    expect(noteToFrequency("A3")).toBeCloseTo(220, 5);
+  });
+
+  it("handles the highest note in the validated range (B8)", () => {
+    expect(noteToFrequency("B8")).toBeGreaterThan(0);
+  });
+
+  it("throws for an invalid note string", () => {
+    expect(() => {
+      noteToFrequency("Z9");
+    }).toThrow("Invalid note: Z9");
+  });
+
+  it("throws for missing octave", () => {
+    expect(() => {
+      noteToFrequency("C");
+    }).toThrow("Invalid note: C");
+  });
+
+  it("throws for flats (only sharps are supported)", () => {
+    expect(() => {
+      noteToFrequency("Bb4");
+    }).toThrow("Invalid note: Bb4");
+  });
+});
+
+describe("frequencyToNote", () => {
+  it("returns A4 with 0 cents for 440 Hz", () => {
+    expect(frequencyToNote(440)).toStrictEqual({cents: 0, note: "A4"});
+  });
+
+  it("returns C4 with ~0 cents for 261.63 Hz", () => {
+    const result = frequencyToNote(261.63);
+
+    expect(result.note).toBe("C4");
+    expect(Math.abs(result.cents)).toBeLessThanOrEqual(1);
+  });
+
+  it("returns positive cents when sharp of the target", () => {
+    const result = frequencyToNote(445);
+
+    expect(result.note).toBe("A4");
+    expect(result.cents).toBeGreaterThan(0);
+  });
+
+  it("returns negative cents when flat of the target", () => {
+    const result = frequencyToNote(435);
+
+    expect(result.note).toBe("A4");
+    expect(result.cents).toBeLessThan(0);
+  });
+
+  it("rounds to the nearest sharp note name", () => {
+    expect(frequencyToNote(noteToFrequency("C#4")).note).toBe("C#4");
+  });
+
+  it("returns the same note after a round-trip", () => {
+    const cases = ["C4", "G4", "F#5", "A3", "D#2"];
+
+    for (const note of cases) {
+      expect(frequencyToNote(noteToFrequency(note)).note).toBe(note);
+    }
+  });
+});
+
+describe("parseSequence", () => {
+  it("splits a single note into a one-element array", () => {
+    expect(parseSequence("G4")).toStrictEqual(["G4"]);
+  });
+
+  it("splits a multi-note sequence on commas", () => {
+    expect(parseSequence("C4,E4,G4")).toStrictEqual(["C4", "E4", "G4"]);
+  });
+
+  it("preserves sharps", () => {
+    expect(parseSequence("C#4,F#4")).toStrictEqual(["C#4", "F#4"]);
+  });
+});

--- a/spec/javascript/music/pitch_detector_spec.ts
+++ b/spec/javascript/music/pitch_detector_spec.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from "vitest";
+import {assert} from "helpers/assert";
+import {detectPitch} from "music/pitch_detector";
+
+const SAMPLE_RATE = 44100;
+
+function generateSine(hz: number, sampleCount: number): Float32Array {
+  const buffer = new Float32Array(sampleCount);
+  for (let index = 0; index < sampleCount; index += 1) {
+    buffer[index] = Math.sin(2 * Math.PI * hz * index / SAMPLE_RATE);
+  }
+
+  return buffer;
+}
+
+function generateSilence(sampleCount: number): Float32Array {
+  return new Float32Array(sampleCount);
+}
+
+function relativeError(detected: number, target: number): number {
+  return Math.abs(detected - target) / target;
+}
+
+describe("detectPitch with default options", () => {
+  it("detects a 440 Hz sine wave within 1%", () => {
+    const samples = generateSine(440, 4096);
+    const detected = assert(detectPitch(samples, SAMPLE_RATE));
+
+    expect(relativeError(detected, 440)).toBeLessThan(0.01);
+  });
+
+  it("detects middle C (~261.63 Hz) within 1%", () => {
+    const samples = generateSine(261.63, 4096);
+    const detected = assert(detectPitch(samples, SAMPLE_RATE));
+
+    expect(relativeError(detected, 261.63)).toBeLessThan(0.01);
+  });
+
+  it("returns null when given a silent buffer", () => {
+    const samples = generateSilence(4096);
+
+    expect(detectPitch(samples, SAMPLE_RATE)).toBeNull();
+  });
+
+  it("returns null when the buffer is too short for the lowest τ", () => {
+    const samples = generateSine(440, 100);
+
+    expect(detectPitch(samples, SAMPLE_RATE)).toBeNull();
+  });
+});
+
+describe("detectPitch with custom options", () => {
+  it("respects a custom threshold for accepting a candidate", () => {
+    const samples = generateSine(440, 4096);
+    const detected =
+      assert(detectPitch(samples, SAMPLE_RATE, {threshold: 0.05}));
+
+    expect(relativeError(detected, 440)).toBeLessThan(0.01);
+  });
+
+  it("respects a custom minHz (raises maxTau, shrinks search range)", () => {
+    const samples = generateSine(440, 4096);
+    const detected =
+      assert(detectPitch(samples, SAMPLE_RATE, {minHz: 200}));
+
+    expect(relativeError(detected, 440)).toBeLessThan(0.01);
+  });
+
+  it("respects a custom maxHz (raises minTau, shrinks search range)", () => {
+    const samples = generateSine(440, 4096);
+    const detected =
+      assert(detectPitch(samples, SAMPLE_RATE, {maxHz: 1000}));
+
+    expect(relativeError(detected, 440)).toBeLessThan(0.01);
+  });
+
+  it("returns null when an impossibly tight threshold rejects all τ", () => {
+    const samples = generateSine(440, 4096);
+
+    expect(detectPitch(samples, SAMPLE_RATE, {threshold: -1})).toBeNull();
+  });
+
+  it("stops the local-min walk when it reaches the maxTau boundary", () => {
+    const samples = generateSine(100, 4096);
+    const detected =
+      assert(detectPitch(samples, SAMPLE_RATE, {minHz: 100}));
+
+    expect(relativeError(detected, 100)).toBeLessThan(0.01);
+  });
+});

--- a/spec/javascript/music/reference_player_spec.ts
+++ b/spec/javascript/music/reference_player_spec.ts
@@ -1,0 +1,201 @@
+import type {AudioContextLike} from "music/reference_player";
+import type {Mock} from "vitest";
+import {describe, expect, it, vi} from "vitest";
+import {assert} from "helpers/assert";
+import {playSequence} from "music/reference_player";
+
+interface MockGain {
+  connect: Mock<(dest: unknown) => void>;
+  gain: {setValueAtTime: Mock<(value: number, when: number) => void>};
+}
+
+interface MockOscillator {
+  connect: Mock<(dest: unknown) => void>;
+  frequency: {value: number};
+  start: Mock<(when: number) => void>;
+  stop: Mock<(when: number) => void>;
+  type: OscillatorType;
+}
+
+interface Harness {
+  ctx: AudioContextLike;
+  destination: object;
+  gains: MockGain[];
+  oscillators: MockOscillator[];
+}
+
+function buildGain(): MockGain {
+  return {
+    connect: vi.fn<(dest: unknown) => void>(),
+    gain: {setValueAtTime: vi.fn<(value: number, when: number) => void>()},
+  };
+}
+
+function buildOscillator(): MockOscillator {
+  return {
+    connect: vi.fn<(dest: unknown) => void>(),
+    frequency: {value: 0},
+    start: vi.fn<(when: number) => void>(),
+    stop: vi.fn<(when: number) => void>(),
+    type: "sawtooth",
+  };
+}
+
+function buildHarness(currentTime = 0): Harness {
+  const oscillators: MockOscillator[] = [];
+  const gains: MockGain[] = [];
+  const destination = {};
+  const ctx: AudioContextLike = {
+    createGain: () => {
+      const gain = buildGain();
+      gains.push(gain);
+
+      return gain;
+    },
+    createOscillator: () => {
+      const osc = buildOscillator();
+      oscillators.push(osc);
+
+      return osc;
+    },
+    currentTime,
+    destination,
+  };
+
+  return {ctx, destination, gains, oscillators};
+}
+
+async function withFakeTimers<T>(fn: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    return await fn();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+async function playAndFlush(
+  harness: Harness,
+  notes: string[],
+  options: Parameters<typeof playSequence>[2] = {},
+): Promise<void> {
+  await withFakeTimers(async () => {
+    const promise = playSequence(harness.ctx, notes, options);
+    await vi.runAllTimersAsync();
+    await promise;
+  });
+}
+
+describe("playSequence creates audio nodes", () => {
+  it("creates one oscillator per note", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, ["A4", "C5"]);
+
+    expect(harness.oscillators).toHaveLength(2);
+  });
+
+  it("creates one gain per note", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, ["A4", "C5"]);
+
+    expect(harness.gains).toHaveLength(2);
+  });
+
+  it("creates no oscillators when notes is empty", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, []);
+
+    expect(harness.oscillators).toHaveLength(0);
+  });
+});
+
+describe("playSequence configures each oscillator", () => {
+  it("sets the oscillator type to sine", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, ["A4"]);
+
+    expect(assert(harness.oscillators[0]).type).toBe("sine");
+  });
+
+  it("sets the oscillator frequency to the note's frequency", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, ["A4"]);
+
+    expect(assert(harness.oscillators[0]).frequency.value).
+      toBeCloseTo(440, 5);
+  });
+
+  it("connects oscillator → gain", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, ["A4"]);
+
+    expect(assert(harness.oscillators[0]).connect).
+      toHaveBeenCalledWith(assert(harness.gains[0]));
+  });
+
+  it("connects gain → destination", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, ["A4"]);
+
+    expect(assert(harness.gains[0]).connect).
+      toHaveBeenCalledWith(harness.destination);
+  });
+});
+
+describe("playSequence schedules with default timings", () => {
+  it("starts each note 600ms apart by default", async () => {
+    const harness = buildHarness(2);
+    await playAndFlush(harness, ["A4", "C5"]);
+
+    expect(assert(harness.oscillators[0]).start).toHaveBeenCalledWith(2);
+    expect(assert(harness.oscillators[1]).start).toHaveBeenCalledWith(2.6);
+  });
+
+  it("stops each note 500ms after its start by default", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, ["A4"]);
+
+    expect(assert(harness.oscillators[0]).stop).toHaveBeenCalledWith(0.5);
+  });
+});
+
+describe("playSequence resolves after total duration", () => {
+  it("resolves after notes.length * (noteDurationMs + gapMs)", async () => {
+    await withFakeTimers(async () => {
+      const harness = buildHarness();
+      let resolved = false;
+      const promise = playSequence(harness.ctx, ["A4", "C5"]).then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1199);
+
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await promise;
+
+      expect(resolved).toBe(true);
+    });
+  });
+});
+
+describe("playSequence honors custom options", () => {
+  it("respects a custom noteDurationMs", async () => {
+    const harness = buildHarness();
+    await playAndFlush(harness, ["A4"], {noteDurationMs: 200});
+
+    expect(assert(harness.oscillators[0]).stop).toHaveBeenCalledWith(0.2);
+  });
+
+  it("respects a custom gapMs in scheduling", async () => {
+    const harness = buildHarness();
+    await playAndFlush(
+      harness,
+      ["A4", "C5"],
+      {gapMs: 50, noteDurationMs: 200},
+    );
+
+    expect(assert(harness.oscillators[1]).start).toHaveBeenCalledWith(0.25);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "controllers/*": ["./app/javascript/controllers/*"],
       "helpers/*": ["./app/javascript/helpers/*"],
       "javascript/*": ["./app/javascript/*"],
+      "music/*": ["./app/javascript/music/*"],
       "support/*": ["./spec/javascript/support/*"]
     },
     "noUncheckedSideEffectImports": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       {find: /^controllers\//u, replacement: appPath("controllers")},
       {find: /^helpers\//u, replacement: appPath("helpers")},
       {find: /^javascript\//u, replacement: appPath("")},
+      {find: /^music\//u, replacement: appPath("music")},
       {find: /^spec\//u, replacement: `${path.resolve(root, "spec")}/`},
       {
         find: /^support\//u,


### PR DESCRIPTION
Pure JS modules under app/javascript/music/ for the upcoming
microphone-driven study experience:

- note_utils.ts — note ↔ frequency conversion, sequence parsing
- pitch_detector.ts — simplified YIN pitch detection from a
  Float32Array; first-below-threshold + local-min walk, no parabolic
  interpolation (sufficient for ±50¢ tolerance, keeps branch coverage
  tractable)
- reference_player.ts — Web Audio sine playback for note sequences,
  injected AudioContextLike so jsdom mocks satisfy the type without
  casts