### PR TITLE
make hot keys exact match

### DIFF
--- a/app/javascript/controllers/hotkeys_controller.ts
+++ b/app/javascript/controllers/hotkeys_controller.ts
@@ -3,18 +3,17 @@ import {Controller} from "@hotwired/stimulus";
 import {assert} from "helpers/assert";
 
 const CTRL_PREFIX = "ctrl+";
-
-function resolveKey(key: string): string {
-  if (key === "Enter") { return " "; }
-  return key;
-}
+const ALT_PREFIX = "alt+";
 
 function resolveEvent(event: KeyboardEvent): string {
-  const isCtrl = event.ctrlKey || event.metaKey;
+  const hasCtrl = event.ctrlKey || event.metaKey;
+  let {key} = event;
 
-  if (isCtrl) { return CTRL_PREFIX + event.key; }
+  if (!hasCtrl && !event.altKey && key === "Enter") { key = " "; }
+  if (event.altKey) { key = ALT_PREFIX + key; }
+  if (hasCtrl) { key = CTRL_PREFIX + key; }
 
-  return resolveKey(event.key);
+  return key;
 }
 
 function isFormField(target: EventTarget | null): boolean {

--- a/spec/javascript/controllers/hotkeys_controller_spec.ts
+++ b/spec/javascript/controllers/hotkeys_controller_spec.ts
@@ -224,3 +224,28 @@ it("does not fire regular hotkeys when ctrl is held", async () => {
 
   expect(clickSpy).not.toHaveBeenCalled();
 });
+
+it("does not fire regular hotkeys when alt is held", async () => {
+  await setupController();
+  const clickSpy = vi.spyOn(button(), "click");
+  const event = new KeyboardEvent("keydown", {altKey: true, key: "a"});
+
+  controller().handleKeydown(event);
+
+  expect(clickSpy).not.toHaveBeenCalled();
+});
+
+it("does not fire ctrl-modified hotkeys when alt is also held", async () => {
+  await setupController();
+  setHotkey("ctrl+Enter");
+  const clickSpy = vi.spyOn(button(), "click");
+  const event = new KeyboardEvent("keydown", {
+    altKey: true,
+    ctrlKey: true,
+    key: "Enter",
+  });
+
+  controller().handleKeydown(event);
+
+  expect(clickSpy).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
When you press `Alt+3` in the browser, it should switch to the 3rd tab
and not select the 3rd item.
