### PR TITLE
DataSets: shim sync data sets with decks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,11 @@ Metrics/BlockLength:
     - config/environments/development.rb
 Rails/FilePath: { EnforcedStyle: slashes }
 Metrics/MethodLength: { Exclude: [db/migrate/**/*.rb] }
+Rails/SkipsModelValidations:
+  # The data_set projection keeps card.item_id as a derived link without
+  # touching the card's timestamps.
+  Exclude:
+    - app/actions/data_sets/projection.rb
 RSpec/MultipleExpectations:
   Exclude:
     - spec/system/**/*.rb

--- a/app/actions/catalog/accept_suggestion.rb
+++ b/app/actions/catalog/accept_suggestion.rb
@@ -18,6 +18,7 @@ module Catalog
         back: suggestion.back,
         category: suggestion.category,
       )
+      DataSets::Projection.project_card(suggestion.card)
     end
 
     class Result

--- a/app/actions/catalog/copy_deck.rb
+++ b/app/actions/catalog/copy_deck.rb
@@ -9,6 +9,7 @@ module Catalog
         return Result.new(success: false, record: new_deck) unless new_deck.save
 
         build_and_insert_cards(new_deck, deck, card_limit:)
+        DataSets::Projection.rebuild(new_deck)
       end
 
       Result.new(success: true, record: new_deck)

--- a/app/actions/data_sets/projection.rb
+++ b/app/actions/data_sets/projection.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# Mirrors a deck's card content into its data_set (items, pairings,
+# item_distractors) during the transition where cards remain the source of
+# truth. Each card projects to one Front item (1:1) plus a Back item per gloss
+# and per distractor, deduped within the set by (side, text).
+module DataSets
+  module Projection
+    FRONT = "Front"
+    BACK = "Back"
+
+    def self.rebuild(deck)
+      data_set = data_set_for(deck)
+      data_set.items.delete_all
+      deck.cards.reload.each { |card| project_card(card) }
+    end
+
+    def self.project_card(card)
+      data_set = data_set_for(card.deck)
+      former_front = card.item
+      former_backs = back_items_for(former_front)
+
+      front = upsert_front(data_set, card)
+      rebuild_links(data_set, front, card)
+      link_card(card, front)
+
+      former_front.destroy! if former_front && former_front != front
+      discard_orphans(former_backs)
+    end
+
+    def self.remove_card(card)
+      front = card.item
+      return unless front
+
+      backs = back_items_for(front)
+      front.destroy!
+      discard_orphans(backs)
+    end
+
+    def self.data_set_for(deck)
+      deck.data_set || create_data_set(deck)
+    end
+
+    def self.create_data_set(deck)
+      data_set = DataSet.create!(user: deck.user, name: deck.name)
+      deck.update!(data_set:)
+      data_set
+    end
+
+    def self.upsert_front(data_set, card)
+      front =
+        data_set.items.find_or_initialize_by(side: FRONT, text: card.front)
+      front.update!(front_attributes(card))
+      front
+    end
+
+    def self.rebuild_links(data_set, front, card)
+      clear_links(front)
+      pair_glosses(data_set, front, glosses(card))
+      link_distractors(data_set, front, terms(card.distractors))
+    end
+
+    def self.link_card(card, front)
+      # item_id is a derived link, kept off the card's timestamps/callbacks.
+      card.update_column(:item_id, front.id)
+    end
+
+    def self.front_attributes(card)
+      {
+        category: card.category,
+        reading: card.reading,
+        example: card.example_front,
+        paired_example: card.example_back,
+      }
+    end
+
+    def self.clear_links(front)
+      Pairing.where(item_id: front.id).delete_all
+      ItemDistractor.where(item_id: front.id).delete_all
+    end
+
+    def self.pair_glosses(data_set, front, glosses)
+      glosses.each do |gloss|
+        back = data_set.items.find_or_create_by!(side: BACK, text: gloss)
+        Pairing.create!(item: front, paired_item: back)
+      end
+    end
+
+    def self.link_distractors(data_set, front, distractors)
+      distractors.each do |distractor|
+        back = data_set.items.find_or_create_by!(side: BACK, text: distractor)
+        ItemDistractor.create!(item: front, distractor_item: back)
+      end
+    end
+
+    def self.glosses(card)
+      terms(card.back.to_s.split(";"))
+    end
+
+    def self.terms(values)
+      values.map { |value| value.to_s.squish }.compact_blank.uniq
+    end
+
+    def self.back_items_for(front)
+      return [] unless front
+
+      paired = Pairing.where(item_id: front.id).select(:paired_item_id)
+      decoys =
+        ItemDistractor.where(item_id: front.id).select(:distractor_item_id)
+      Item.where(id: paired).or(Item.where(id: decoys)).to_a
+    end
+
+    def self.discard_orphans(items)
+      items.each do |item|
+        next if Pairing.exists?(paired_item_id: item.id)
+        next if ItemDistractor.exists?(distractor_item_id: item.id)
+
+        item.destroy!
+      end
+    end
+  end
+end

--- a/app/actions/decks/create.rb
+++ b/app/actions/decks/create.rb
@@ -12,12 +12,16 @@ module Decks
       return failure(deck, error) if error
 
       deck.distractor_pool = distractors_column?(csv) ? "preset" : "category"
+      persist(deck, user, csv)
+    end
 
+    def self.persist(deck, user, csv)
       ActiveRecord::Base.transaction do
         deck.user = user
         return failure(deck) unless deck.save
 
         build_and_insert_cards(deck, collect_cards_data(csv))
+        DataSets::Projection.rebuild(deck)
       end
 
       Result.new(success: true, record: deck)

--- a/app/actions/decks/replace.rb
+++ b/app/actions/decks/replace.rb
@@ -16,6 +16,7 @@ module Decks
       ActiveRecord::Base.transaction do
         deck.update!(distractor_pool: derive_distractor_pool(csv))
         summary = apply_diff(deck, Decks::Create.collect_cards_data(csv))
+        DataSets::Projection.rebuild(deck)
       end
 
       Result.new(success: true, record: deck, summary:)

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class CardsController < ApplicationController
+  include ProjectsCards
+
   def update
     deck = current_user.decks.find(params.expect(:deck_id))
     card = deck.cards.find(params.expect(:id))
 
-    if card.update(card_params)
+    if save_card(card)
       update_succeeded(deck, card)
     else
       update_failed(deck, card)
@@ -14,7 +16,8 @@ class CardsController < ApplicationController
 
   def destroy
     deck = current_user.decks.find(params.expect(:deck_id))
-    deck.cards.find(params.expect(:id)).destroy!
+    destroy_card(deck.cards.find(params.expect(:id)))
+
     flash[:success] = t(".success")
     redirect_to(deck_study_path(deck))
   end
@@ -35,14 +38,7 @@ class CardsController < ApplicationController
 
   def card_params
     params.expect(
-      card: [
-        :front,
-        :back,
-        :category,
-        :reading,
-        :example_front,
-        :example_back,
-      ],
+      card: [:front, :back, :category, :reading, :example_front, :example_back],
     )
   end
 

--- a/app/controllers/concerns/projects_cards.rb
+++ b/app/controllers/concerns/projects_cards.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Wraps card writes so the data_set projection stays in sync atomically.
+module ProjectsCards
+  extend ActiveSupport::Concern
+
+  private
+
+  def save_card(card)
+    ActiveRecord::Base.transaction do
+      next false unless card.update(card_params)
+
+      DataSets::Projection.project_card(card)
+      true
+    end
+  end
+
+  def destroy_card(card)
+    ActiveRecord::Base.transaction do
+      DataSets::Projection.remove_card(card)
+      card.destroy!
+    end
+  end
+end

--- a/app/domain/study.rb
+++ b/app/domain/study.rb
@@ -81,9 +81,12 @@ class Study
         level_completed:,
       )
     else
-      card.distractors.unshift(answer).uniq!
-      card.correct_streak = 0
-      card.save!
+      ActiveRecord::Base.transaction do
+        card.distractors.unshift(answer).uniq!
+        card.correct_streak = 0
+        card.save!
+        DataSets::Projection.project_card(card)
+      end
       Result.new(
         card:,
         correct: false,

--- a/db/migrate/20260626000000_add_paired_example_to_items.rb
+++ b/db/migrate/20260626000000_add_paired_example_to_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPairedExampleToItems < ActiveRecord::Migration[8.1]
+  def change
+    add_column(:items, :paired_example, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_25_000005) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -97,6 +97,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_000005) do
     t.datetime "created_at", null: false
     t.bigint "data_set_id", null: false
     t.string "example"
+    t.string "paired_example"
     t.string "reading"
     t.string "side", null: false
     t.string "text", null: false

--- a/spec/actions/catalog/accept_suggestion_spec.rb
+++ b/spec/actions/catalog/accept_suggestion_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Catalog::AcceptSuggestion do
       expect(suggestion.card.reload.back).to eq("New back")
     end
 
+    it "mirrors the accepted edit into the data_set" do
+      suggestion = build_suggestion
+      described_class.call(suggestion:)
+
+      expect_projection_matches(suggestion.card.deck)
+      expect(suggestion.card.reload.item.text).to eq("New")
+    end
+
     it "overwrites the card's category" do
       suggestion = build_suggestion
       described_class.call(suggestion:)

--- a/spec/actions/catalog/copy_deck_spec.rb
+++ b/spec/actions/catalog/copy_deck_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe Catalog::CopyDeck do
       expect(result.record.cards.count).to eq(2)
     end
 
+    it "mirrors the copied cards into a data_set" do
+      source = build_public_deck
+      create(:card, deck: source, front: "Q1", back: "A1;A2")
+      result = described_class.call(user: create(:user), deck: source)
+
+      expect(result.record.data_set).to be_present
+      expect_projection_matches(result.record)
+    end
+
     it "copies card front" do
       source = build_public_deck
       create(:card, deck: source, front: "Q", back: "Paris")

--- a/spec/actions/data_sets/projection_spec.rb
+++ b/spec/actions/data_sets/projection_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataSets::Projection do
+  def deck_with(backs)
+    deck = create(:deck)
+    backs.each_with_index do |back, index|
+      create(:card, deck:, front: "f#{index}", back:)
+    end
+    described_class.rebuild(deck)
+    deck
+  end
+
+  def annotated_card(deck)
+    create(
+      :card,
+      deck:,
+      front: "明白",
+      back: "understand",
+      category: "Verbs",
+      reading: "míngbai",
+      example_front: "我明白",
+      example_back: "I understand",
+    )
+  end
+
+  def deck_with_decoy_glossed_elsewhere
+    deck = create(:deck)
+    create(:card, deck:, front: "a", back: "z", distractors: ["x"])
+    create(:card, deck:, front: "b", back: "x")
+    described_class.rebuild(deck)
+    deck
+  end
+
+  def back_texts(deck)
+    deck.reload.data_set.items.where(side: "Back").pluck(:text)
+  end
+
+  def front_texts(deck)
+    deck.reload.data_set.items.where(side: "Front").pluck(:text)
+  end
+
+  describe ".rebuild" do
+    it "names the data_set after the deck" do
+      deck = create(:deck, name: "HSK 1")
+      create(:card, deck:)
+      described_class.rebuild(deck)
+
+      expect(deck.reload.data_set.name).to eq("HSK 1")
+    end
+
+    it "carries a card's annotations onto its Front item" do
+      deck = create(:deck)
+      annotated_card(deck)
+      described_class.rebuild(deck)
+
+      expect_projection_matches(deck)
+    end
+
+    it "splits a semicolon back into multiple Back items" do
+      deck = deck_with(["understand; clear; obvious"])
+
+      expect(back_texts(deck))
+        .to contain_exactly("understand", "clear", "obvious")
+    end
+
+    it "links each card to its Front item" do
+      deck = deck_with(["understand"])
+
+      expect(deck.cards.first.reload.item.text).to eq("f0")
+    end
+
+    it "dedups a gloss shared across cards into one Back item" do
+      deck = deck_with(["clear", "clear"])
+
+      expect(back_texts(deck)).to contain_exactly("clear")
+    end
+
+    it "projects distractors as referenced Back items" do
+      deck = create(:deck)
+      create(:card, deck:, front: "f", back: "a", distractors: ["x", "y"])
+      described_class.rebuild(deck)
+
+      expect_projection_matches(deck)
+    end
+
+    it "drops content no longer present on a later rebuild" do
+      deck = deck_with(["understand"])
+      deck.cards.first.update!(back: "clear")
+      described_class.rebuild(deck)
+
+      expect(back_texts(deck)).to contain_exactly("clear")
+    end
+  end
+
+  describe ".project_card" do
+    it "removes a Back item orphaned by a changed back" do
+      deck = deck_with(["understand"])
+      deck.cards.first.update!(back: "clear")
+      described_class.project_card(deck.cards.first)
+
+      expect(back_texts(deck)).to contain_exactly("clear")
+    end
+
+    it "keeps a Back item still shared by another card" do
+      deck = deck_with(["clear", "clear"])
+      card = deck.cards.find_by(front: "f1")
+      card.update!(back: "bright")
+      described_class.project_card(card)
+
+      expect(back_texts(deck)).to include("clear")
+    end
+
+    it "discards the old Front item when the front changes" do
+      deck = deck_with(["understand"])
+      card = deck.cards.first
+      card.update!(front: "懂")
+      described_class.project_card(card)
+
+      expect(front_texts(deck)).to contain_exactly("懂")
+    end
+  end
+
+  describe ".remove_card" do
+    it "removes the card's Front item and orphaned Back items" do
+      deck = deck_with(["understand"])
+      described_class.remove_card(deck.cards.first)
+      deck.cards.first.destroy!
+
+      expect(deck.reload.data_set.items).to be_empty
+    end
+
+    it "keeps Back items still used by another card" do
+      deck = deck_with(["clear", "clear"])
+      card = deck.cards.find_by(front: "f1")
+      described_class.remove_card(card)
+      card.destroy!
+
+      expect(back_texts(deck)).to contain_exactly("clear")
+    end
+
+    it "keeps a Back item still referenced as a distractor" do
+      deck = deck_with_decoy_glossed_elsewhere
+      card = deck.cards.find_by(front: "b")
+      described_class.remove_card(card)
+      card.destroy!
+
+      expect(back_texts(deck)).to include("x")
+    end
+  end
+end

--- a/spec/actions/decks/create_spec.rb
+++ b/spec/actions/decks/create_spec.rb
@@ -83,6 +83,16 @@ RSpec.describe Decks::Create do
       end
     end
 
+    context "when mirroring to a data_set" do
+      it "mirrors the cards into a matching data_set" do
+        user = create(:user)
+        csv = csv_file("front,back\n明白,understand;clear\n")
+        deck = described_class.call(user:, name: "T", cards_csv: csv).record
+
+        expect_projection_matches(deck)
+      end
+    end
+
     context "when CSV has a distractors column" do
       it "stores distractors on the card" do
         user = create(:user)

--- a/spec/actions/decks/replace_spec.rb
+++ b/spec/actions/decks/replace_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe Decks::Replace do
       Card.where(deck_id: deck.id).pluck(:front)
     end
 
+    context "when mirroring to a data_set" do
+      it "rebuilds the data_set to match the replaced cards" do
+        deck = create(:deck)
+        card_with_progress(deck, front: "Q", back: "old", category: "C")
+        replace_with(deck, "front,back,category\nQ,new;fresh,C\nR,new2,C\n")
+
+        expect_projection_matches(deck)
+      end
+    end
+
     context "when a kept card is completely unchanged" do
       it "does not touch updated_at" do
         deck = create(:deck)

--- a/spec/domain/study_spec.rb
+++ b/spec/domain/study_spec.rb
@@ -445,6 +445,15 @@ RSpec.describe Study do
         expect(card.reload.distractors).to eq(["London"])
       end
 
+      it "mirrors the new distractor into the data_set" do
+        card = create(:card, back: "Paris")
+        DataSets::Projection.rebuild(card.deck)
+        described_class.new(deck: card.deck)
+          .answer_card(card_id: card.id, answer: "London")
+
+        expect_projection_matches(card.deck)
+      end
+
       it "prepends wrong answer to existing list" do
         card = create(:card, back: "Paris", distractors: ["Berlin"])
         study = described_class.new(deck: card.deck)

--- a/spec/requests/cards_controller_spec.rb
+++ b/spec/requests/cards_controller_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe CardsController do
           .from("Original Front").to("New Front")
       end
 
+      it "keeps the data_set consistent after an edit" do
+        card = create(:card, back: "old")
+        DataSets::Projection.rebuild(card.deck)
+        update_card(deck: card.deck, card:, back: "new;fresh")
+
+        expect_projection_matches(card.deck)
+      end
+
       it "replaces the card question on the page" do
         deck = create(:deck)
         card = create(:card, deck:, front: "Original Front")
@@ -209,6 +217,15 @@ RSpec.describe CardsController do
 
       expect { delete(deck_card_path(deck, card)) }
         .to change(Card, :count).by(-1)
+    end
+
+    it "keeps the data_set consistent after a delete" do
+      card = create(:card, back: "x")
+      DataSets::Projection.rebuild(card.deck)
+      login_as(default_user)
+      delete(deck_card_path(card.deck, card))
+
+      expect_projection_matches(card.deck)
     end
 
     it "redirects to the deck study path" do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -2,3 +2,4 @@
 
 require_relative "helpers/request_spec_helpers"
 require_relative "helpers/system_spec_helpers"
+require_relative "helpers/data_set_projection_helpers"

--- a/spec/support/helpers/data_set_projection_helpers.rb
+++ b/spec/support/helpers/data_set_projection_helpers.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Helpers
+  # Drift oracle for the data_set dual-write: derives the projection a deck's
+  # cards *should* produce (independently of DataSets::Projection) and compares
+  # it to the live data_set, so any path that mirrors incorrectly is caught.
+  module DataSetProjectionHelpers
+    BACK_ATTRS = {
+      category: nil, reading: nil, example: nil, paired_example: nil
+    }.freeze
+
+    def expect_projection_matches(deck)
+      expect(actual_projection(deck)).to eq(expected_projection(deck))
+    end
+
+    def expected_projection(deck)
+      result = { items: {}, pairings: [], distractors: [] }
+      deck.cards.each { |card| add_card(result, card) }
+      result[:pairings].sort!
+      result[:distractors].sort!
+      result
+    end
+
+    def add_card(result, card)
+      result[:items][["Front", card.front]] = front_attrs(card)
+      decoys = split(card.distractors.join(";"))
+      add_side(result, :pairings, card.front, split(card.back))
+      add_side(result, :distractors, card.front, decoys)
+    end
+
+    def add_side(result, key, front, texts)
+      texts.each do |text|
+        result[:items][["Back", text]] ||= BACK_ATTRS
+        result[key] << [front, text]
+      end
+    end
+
+    def actual_projection(deck)
+      data_set = deck.reload.data_set
+      return { items: {}, pairings: [], distractors: [] } unless data_set
+
+      by_id = data_set.items.index_by(&:id)
+      {
+        items: by_id.values.to_h { |i| [[i.side, i.text], item_attrs(i)] },
+        pairings: link_pairs(Pairing, by_id, :paired_item_id),
+        distractors: link_pairs(ItemDistractor, by_id, :distractor_item_id),
+      }
+    end
+
+    def link_pairs(model, by_id, target)
+      model.where(item_id: by_id.keys)
+        .map { |row| [by_id[row.item_id].text, by_id[row[target]].text] }
+        .sort
+    end
+
+    def front_attrs(card)
+      {
+        category: card.category,
+        reading: card.reading,
+        example: card.example_front,
+        paired_example: card.example_back,
+      }
+    end
+
+    def item_attrs(item)
+      item.slice(:category, :reading, :example, :paired_example).symbolize_keys
+    end
+
+    def split(value)
+      value.to_s.split(";").map(&:squish).compact_blank.uniq
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(Helpers::DataSetProjectionHelpers)
+end


### PR DESCRIPTION
This adds shim logic to create/maintain data sets alongside decks/cards.
