### PR TITLE
don't require consecutive words for fuzzy match

### DIFF
--- a/app/javascript/controllers/fuzzy_find_controller.ts
+++ b/app/javascript/controllers/fuzzy_find_controller.ts
@@ -31,29 +31,30 @@ function normalize(text: string): string {
   return result;
 }
 
-function matchesAt(
+function findPrefixWord(
   answerWords: string[],
-  queryWords: string[],
+  queryWord: string,
   start: number,
-): boolean {
-  for (const [offset, queryWord] of queryWords.entries()) {
-    const word = answerWords[start + offset];
-    if (word === undefined) { return false; }
-    if (!word.startsWith(queryWord)) { return false; }
+): number {
+  for (let index = start; index < answerWords.length; index += 1) {
+    if (answerWords[index]?.startsWith(queryWord) === true) { return index; }
   }
 
-  return true;
+  return -1;
 }
 
 function hasPrefixMatch(
   answerWords: string[],
   queryWords: string[],
 ): boolean {
-  for (let start = 0; start < answerWords.length; start += 1) {
-    if (matchesAt(answerWords, queryWords, start)) { return true; }
+  let start = 0;
+  for (const queryWord of queryWords) {
+    const index = findPrefixWord(answerWords, queryWord, start);
+    if (index === -1) { return false; }
+    start = index + 1;
   }
 
-  return false;
+  return true;
 }
 
 function totalChars(words: string[]): number {

--- a/spec/javascript/controllers/fuzzy_find_controller_spec.ts
+++ b/spec/javascript/controllers/fuzzy_find_controller_spec.ts
@@ -152,7 +152,7 @@ describe("filter matching", () => {
 });
 
 describe("filter multi-word matching", () => {
-  it("matches consecutive words when the query has whitespace", async () => {
+  it("matches adjacent words when the query has whitespace", async () => {
     const controller = await boot(["last name", "first name", "lastly"]);
 
     await typeAndFilter(controller, "last name");
@@ -160,7 +160,7 @@ describe("filter multi-word matching", () => {
     expect(matchTexts()).toStrictEqual(["last name"]);
   });
 
-  it("matches consecutive word prefixes inside a phrase", async () => {
+  it("matches word prefixes inside a phrase", async () => {
     const controller = await boot([
       "the quick brown fox",
       "quick fox",
@@ -172,6 +172,16 @@ describe("filter multi-word matching", () => {
     expect(matchTexts()).toStrictEqual(["the quick brown fox"]);
   });
 
+  it("matches word prefixes separated by other words", async () => {
+    const controller = await boot(["to have a beard", "to be happy"]);
+
+    await typeAndFilter(controller, "ha be");
+
+    expect(matchTexts()).toStrictEqual(["to have a beard"]);
+  });
+});
+
+describe("filter multi-word edge cases", () => {
   it("does not match when query words are out of order", async () => {
     const controller = await boot(["the quick brown fox"]);
 


### PR DESCRIPTION
With the existing implementation, typing "ha be" wouldn't match "to have
a beard" because it only checks consecutive words after the first
matched word. This change allows matching words that aren't consecutive,
but still requires them in order.
