### PR TITLE
add streak pips to right answer

### DIFF
--- a/app/assets/stylesheets/flash.css
+++ b/app/assets/stylesheets/flash.css
@@ -633,6 +633,36 @@ body {
   box-shadow: none;
 }
 
+.answer-streak {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.answer-streak__pips {
+  display: inline-flex;
+  gap: 5px;
+}
+
+.streak-pip {
+  width: 11px;
+  height: 11px;
+  border: 2px solid var(--color-success-border);
+}
+
+.streak-pip--filled {
+  background: var(--color-success-border);
+}
+
+.answer-streak__count {
+  color: var(--color-success-dark);
+  font-size: 12px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  letter-spacing: 0.5px;
+}
+
 .study-example {
   margin: var(--spacing-md) 0 var(--spacing-lg);
   padding: var(--spacing-md) var(--spacing-lg);

--- a/app/views/studies/update.rb
+++ b/app/views/studies/update.rb
@@ -117,6 +117,7 @@ module Views
                   answer_id =
                     ("correct-answer-text" if answer == result.correct_answer)
                   span(class: "answer-text", id: answer_id) { answer }
+                  render_streak_pips if show_streak_pips?(answer)
                 end
               end
             end
@@ -153,6 +154,22 @@ module Views
             span { "Next Card" }
             span(class: "hotkey-hint") { "[space]" }
           end
+        end
+      end
+
+      def show_streak_pips?(answer)
+        answer == result.correct_answer && result.correct? && deck.level > 1
+      end
+
+      def render_streak_pips
+        filled = [result.card.correct_streak, deck.level].min
+        span(class: "answer-streak") do
+          span(class: "answer-streak__pips", aria: { hidden: "true" }) do
+            deck.level.times do |i|
+              span(class: ["streak-pip", ("streak-pip--filled" if i < filled)])
+            end
+          end
+          span(class: "answer-streak__count") { "#{filled}/#{deck.level}" }
         end
       end
 

--- a/spec/requests/studies_controller_spec.rb
+++ b/spec/requests/studies_controller_spec.rb
@@ -295,6 +295,41 @@ RSpec.describe StudiesController do
 
         expect(rendered).to have_css(".answer-faded", text: "London")
       end
+
+      it "does not show streak pips at level 1" do
+        card = create(:card, deck:, back: "Paris", correct_streak: 0)
+        create(:card, deck:)
+        submit_answer(card:, answer: "Paris")
+
+        expect(rendered).to have_no_css(".answer-streak")
+      end
+
+      it "shows streak progress at level 2" do
+        deck.update!(level: 2)
+        card = create(:card, deck:, back: "Paris", correct_streak: 0)
+        create(:card, deck:)
+        submit_answer(card:, answer: "Paris")
+
+        expect(rendered).to have_css(".answer-streak", text: "1/2")
+      end
+
+      it "fills one pip per correct answer in a row" do
+        deck.update!(level: 2)
+        card = create(:card, deck:, back: "Paris", correct_streak: 0)
+        create(:card, deck:)
+        submit_answer(card:, answer: "Paris")
+
+        expect(rendered).to have_css(".streak-pip--filled", count: 1)
+      end
+
+      it "shows all pips filled when the card clears" do
+        deck.update!(level: 2)
+        card = create(:card, deck:, back: "Paris", correct_streak: 1)
+        create(:card, deck:, correct_streak: 0)
+        submit_answer(card:, answer: "Paris")
+
+        expect(rendered).to have_css(".streak-pip--filled", count: 2)
+      end
     end
 
     context "when answer is incorrect" do
@@ -325,6 +360,14 @@ RSpec.describe StudiesController do
         submit_answer(card:, answer: "London")
 
         expect(rendered).to have_css(".answer-correct", text: "Paris")
+      end
+
+      it "does not show streak pips" do
+        deck.update!(level: 2)
+        card = create(:card, deck:, back: "Paris")
+        submit_answer(card:, answer: "London")
+
+        expect(rendered).to have_no_css(".answer-streak")
       end
 
       it "shows the next card link" do


### PR DESCRIPTION
Users have been confused when the progress bar doesn't increment when
they get a correct answer on levels > 1. This is because we don't
increment the progress bar until they reach the correct streak for that
level. This reveals that mechanic a bit more.
