### PR TITLE
move example text to pop-up

### DIFF
--- a/app/assets/stylesheets/flash.css
+++ b/app/assets/stylesheets/flash.css
@@ -663,12 +663,94 @@ body {
   letter-spacing: 0.5px;
 }
 
-.study-example {
-  margin: var(--spacing-md) 0 var(--spacing-lg);
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-left: 4px solid var(--color-border-medium);
-  background: var(--color-background-subtle);
+.study-example__toggle {
+  position: absolute;
+  left: 12px;
+  bottom: 6px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 8px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  transition: color var(--transition), background var(--transition);
   animation: answer-reveal var(--transition-slow) ease-out;
+}
+
+.study-example__toggle:hover,
+.study-example__toggle:focus-visible {
+  color: var(--color-text);
+  background: rgb(var(--color-foreground-channels) / 6%);
+  outline: none;
+}
+
+.study-example__toggle[aria-expanded="true"] {
+  color: var(--color-primary-dark);
+  background: rgb(var(--color-primary-channels) / 8%);
+}
+
+.study-example {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 4%;
+  right: 4%;
+  z-index: 5;
+  padding: var(--spacing-md) var(--spacing-lg);
+  border: 3px solid var(--color-border-dark);
+  border-left: 6px solid var(--color-accent);
+  background: var(--color-background-elevated);
+  box-shadow:
+    4px 4px 0 -2px var(--color-background),
+    4px 4px 0 0 var(--color-border-dark),
+    0 6px 18px rgb(var(--color-foreground-channels) / 12%);
+  text-align: left;
+  animation: example-drop var(--transition-slow) ease-out;
+}
+
+@keyframes example-drop {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.study-example__label {
+  margin: 0 0 var(--spacing-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+.study-example__close {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  padding: 4px 8px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 14px;
+  cursor: pointer;
+  transition: color var(--transition);
+}
+
+.study-example__close:hover,
+.study-example__close:focus-visible {
+  color: var(--color-text);
+  outline: none;
 }
 
 .study-example__front {

--- a/app/components/study_example.rb
+++ b/app/components/study_example.rb
@@ -10,14 +10,72 @@ module Components
     end
 
     def view_template
-      div(id: WRAPPER_ID) do
-        next if @card.example_front.blank? || @card.example_back.blank?
-
-        div(class: "study-example") do
-          p(class: "study-example__front") { @card.example_front }
-          p(class: "study-example__back") { @card.example_back }
+      if example?
+        div(id: WRAPPER_ID, data: wrapper_data) do
+          render_toggle
+          render_panel
         end
+      else
+        div(id: WRAPPER_ID)
       end
+    end
+
+    private
+
+    def example?
+      @card.example_front.present? && @card.example_back.present?
+    end
+
+    def wrapper_data
+      {
+        controller: "disclosure",
+        action:
+          "click@window->disclosure#handleDocClick " \
+          "keydown@window->disclosure#handleEsc",
+      }
+    end
+
+    def render_toggle
+      button(
+        type: "button",
+        class: "study-example__toggle",
+        aria: { expanded: "false" },
+        data: toggle_data,
+      ) do
+        plain("💬 example")
+        span(class: "hotkey-hint") { "[x]" }
+      end
+    end
+
+    def toggle_data
+      {
+        disclosure_target: "toggle",
+        action: "click->disclosure#toggle",
+        hotkeys_target: "click",
+        hotkey: "x",
+      }
+    end
+
+    def render_panel
+      div(
+        class: "study-example",
+        hidden: true,
+        data: { disclosure_target: "panel" },
+      ) do
+        p(class: "study-example__label") { "Example" }
+        render_close
+        p(class: "study-example__front") { @card.example_front }
+        p(class: "study-example__back") { @card.example_back }
+      end
+    end
+
+    def render_close
+      button(
+        type: "button",
+        class: "study-example__close",
+        aria: { label: "Close example" },
+        data: { action: "click->disclosure#close" },
+      ) { "✕" }
     end
   end
 end

--- a/app/javascript/controllers/disclosure_controller.ts
+++ b/app/javascript/controllers/disclosure_controller.ts
@@ -1,0 +1,38 @@
+import {Controller} from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static override targets = ["toggle", "panel"];
+
+  declare toggleTarget: HTMLButtonElement;
+
+  declare panelTarget: HTMLElement;
+
+  private isOpen = false;
+
+  toggle(): void {
+    this.setOpen(!this.isOpen);
+  }
+
+  close(): void {
+    this.setOpen(false);
+  }
+
+  handleDocClick(event: MouseEvent): void {
+    if (!this.isOpen) { return; }
+    if (!(event.target instanceof Node)) { return; }
+    if (this.element.contains(event.target)) { return; }
+    this.setOpen(false);
+  }
+
+  handleEsc(event: KeyboardEvent): void {
+    if (event.key !== "Escape") { return; }
+    if (!this.isOpen) { return; }
+    this.setOpen(false);
+  }
+
+  private setOpen(open: boolean): void {
+    this.isOpen = open;
+    this.panelTarget.hidden = !open;
+    this.toggleTarget.setAttribute("aria-expanded", String(open));
+  }
+}

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -24,6 +24,9 @@ application.register("deck-type", DeckTypeController);
 import DialogController from "./dialog_controller";
 application.register("dialog", DialogController);
 
+import DisclosureController from "./disclosure_controller";
+application.register("disclosure", DisclosureController);
+
 import FileUploadController from "./file_upload_controller";
 application.register("file-upload", FileUploadController);
 

--- a/app/views/studies/update.rb
+++ b/app/views/studies/update.rb
@@ -105,9 +105,8 @@ module Views
                 },
               ) { "✏" }
             end
+            render(Components::StudyExample.new(card:))
           end
-
-          render(Components::StudyExample.new(card:))
 
           ol(class: "study-answers-grid") do
             result.possible_answers.each do |answer|

--- a/spec/components/study_example_spec.rb
+++ b/spec/components/study_example_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe Components::StudyExample do
     expect(html).to include("Bonjour le monde", "Hello world")
   end
 
+  it "renders a toggle bound to the x hotkey" do
+    html = render_for("Bonjour le monde", "Hello world")
+
+    expect(html).to include("study-example__toggle", %(data-hotkey="x"))
+  end
+
+  it "renders the panel hidden" do
+    html = render_for("Bonjour le monde", "Hello world")
+
+    expect(html).to include(%(class="study-example" hidden))
+  end
+
   it "renders an empty wrapper when both example fields are blank" do
     expect(render_for(nil, nil)).to eq(%(<div id="study-example"></div>))
   end

--- a/spec/javascript/controllers/disclosure_controller_spec.ts
+++ b/spec/javascript/controllers/disclosure_controller_spec.ts
@@ -1,0 +1,134 @@
+import {describe, expect, it} from "vitest";
+import {
+  boot,
+  clickEventOn,
+  controller,
+  keyEvent,
+  open,
+  panel,
+  toggle as toggleButton,
+} from "support/disclosure_harness";
+
+describe("toggle", () => {
+  it("opens a closed panel", async () => {
+    await boot();
+
+    open();
+
+    expect(panel().hidden).toBe(false);
+  });
+
+  it("sets aria-expanded to true when opening", async () => {
+    await boot();
+
+    open();
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("closes an open panel", async () => {
+    await boot();
+    open();
+
+    controller().toggle();
+
+    expect(panel().hidden).toBe(true);
+  });
+
+  it("sets aria-expanded to false when closing", async () => {
+    await boot();
+    open();
+
+    controller().toggle();
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+describe("close", () => {
+  it("closes an open panel", async () => {
+    await boot();
+    open();
+
+    controller().close();
+
+    expect(panel().hidden).toBe(true);
+  });
+
+  it("leaves a closed panel closed", async () => {
+    await boot();
+
+    controller().close();
+
+    expect(panel().hidden).toBe(true);
+  });
+});
+
+describe("handleDocClick", () => {
+  it("closes when an open panel is clicked outside the wrapper", async () => {
+    await boot();
+    open();
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+
+    controller().handleDocClick(clickEventOn(outside));
+
+    expect(panel().hidden).toBe(true);
+  });
+
+  it("leaves the panel open when the click is inside the wrapper", async () => {
+    await boot();
+    open();
+
+    controller().handleDocClick(clickEventOn(panel()));
+
+    expect(panel().hidden).toBe(false);
+  });
+
+  it("does nothing when the panel is already closed", async () => {
+    await boot();
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+
+    controller().handleDocClick(clickEventOn(outside));
+
+    expect(panel().hidden).toBe(true);
+  });
+
+  it("ignores clicks whose target is not a DOM node", async () => {
+    await boot();
+    open();
+
+    controller().handleDocClick(clickEventOn({notANode: true}));
+
+    expect(panel().hidden).toBe(false);
+  });
+});
+
+describe("handleEsc", () => {
+  it("closes an open panel when Escape is pressed", async () => {
+    await boot();
+    open();
+
+    controller().handleEsc(keyEvent("Escape"));
+
+    expect(panel().hidden).toBe(true);
+  });
+
+  it("ignores non-Escape keys", async () => {
+    await boot();
+    open();
+
+    controller().handleEsc(keyEvent("a"));
+
+    expect(panel().hidden).toBe(false);
+  });
+
+  it("does nothing when the panel is already closed", async () => {
+    await boot();
+
+    controller().handleEsc(keyEvent("Escape"));
+
+    expect(panel().hidden).toBe(true);
+  });
+});

--- a/spec/javascript/support/disclosure_harness.ts
+++ b/spec/javascript/support/disclosure_harness.ts
@@ -1,0 +1,81 @@
+import {bootStimulus, getController} from "support/stimulus";
+import DisclosureController from "controllers/disclosure_controller";
+import {ensure} from "helpers/ensure";
+
+const ROOT_SEL = "[data-controller='disclosure']";
+const TOGGLE_SEL = "[data-disclosure-target='toggle']";
+const PANEL_SEL = "[data-disclosure-target='panel']";
+
+function buildToggle(): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.dataset.disclosureTarget = "toggle";
+  button.setAttribute("aria-expanded", "false");
+
+  return button;
+}
+
+function buildPanel(): HTMLElement {
+  const div = document.createElement("div");
+  div.dataset.disclosureTarget = "panel";
+  div.hidden = true;
+
+  return div;
+}
+
+function setupDOM(): void {
+  const root = document.createElement("div");
+  root.dataset.controller = "disclosure";
+
+  root.appendChild(buildToggle());
+  root.appendChild(buildPanel());
+
+  document.body.replaceChildren(root);
+}
+
+async function boot(): Promise<void> {
+  setupDOM();
+  await bootStimulus("disclosure", DisclosureController);
+}
+
+function element(): HTMLElement {
+  return ensure(document.querySelector<HTMLElement>(ROOT_SEL));
+}
+
+function controller(): DisclosureController {
+  return getController(element(), "disclosure", DisclosureController);
+}
+
+function toggle(): HTMLButtonElement {
+  return ensure(document.querySelector<HTMLButtonElement>(TOGGLE_SEL));
+}
+
+function panel(): HTMLElement {
+  return ensure(document.querySelector<HTMLElement>(PANEL_SEL));
+}
+
+function clickEventOn(target: unknown): MouseEvent {
+  const event = new MouseEvent("click");
+  Object.defineProperty(event, "target", {value: target});
+
+  return event;
+}
+
+function keyEvent(key: string): KeyboardEvent {
+  return new KeyboardEvent("keydown", {key});
+}
+
+function open(): void {
+  controller().toggle();
+}
+
+export {
+  boot,
+  clickEventOn,
+  controller,
+  element,
+  keyEvent,
+  open,
+  panel,
+  toggle,
+};

--- a/spec/system/studies_spec.rb
+++ b/spec/system/studies_spec.rb
@@ -52,12 +52,39 @@ RSpec.describe "studying a deck" do
       visit(deck_study_path(default_deck))
     end
 
-    it "shows the example after answering" do
+    it "shows the example when toggled after answering" do
       visit_card_with_example
       click_on("Paris")
+      click_on("example")
 
       expect(page).to have_text("Je vis à Paris.")
       expect(page).to have_text("I live in Paris.")
+    end
+
+    it "keeps the example hidden until toggled" do
+      visit_card_with_example
+      click_on("Paris")
+
+      expect(page).to have_css(".study-example__toggle")
+      expect(page).to have_no_text("Je vis à Paris.")
+    end
+
+    it "hides the example again with the close button" do
+      visit_card_with_example
+      click_on("Paris")
+      click_on("example")
+      click_on("Close example")
+
+      expect(page).to have_no_text("Je vis à Paris.")
+    end
+
+    it "toggles the example with the x hotkey" do
+      visit_card_with_example
+      click_on("Paris")
+
+      find("body").send_keys("x")
+
+      expect(page).to have_text("Je vis à Paris.")
     end
 
     it "does not show the example before answering" do
@@ -67,12 +94,12 @@ RSpec.describe "studying a deck" do
     end
   end
 
-  it "does not render an example block when the card has no example" do
+  it "does not render an example toggle when the card has no example" do
     default_deck.update!(level: 2)
     create(:card, deck: default_deck, back: "Paris")
     answer_first_card("Paris")
 
-    expect(page).to have_no_css(".study-example")
+    expect(page).to have_no_css(".study-example__toggle")
   end
 
   def answer_first_card(answer)


### PR DESCRIPTION
The example text causes the layout to bump down, which is kind of
jarring in the UI. Instead, this adds a toggle for the user to view it
on demand.
