### PR TITLE
persist "Mix" font when answer is wrong

### DIFF
--- a/app/components/card_front.rb
+++ b/app/components/card_front.rb
@@ -2,12 +2,13 @@
 
 module Components
   class CardFront < Components::Base
-    def initialize(text:, id: nil, reading: nil, font_menu: false)
+    def initialize(text:, id: nil, reading: nil, font_menu: false, card_id: nil)
       super()
       @text = text
       @id = id
       @reading = reading
       @font_menu = font_menu
+      @card_id = card_id
     end
 
     def view_template
@@ -22,12 +23,15 @@ module Components
     private
 
     def wrapper_data
-      {
+      data = {
         controller: "disclosure",
         action:
           "click@window->disclosure#handleDocClick " \
           "keydown@window->disclosure#handleEsc",
       }
+      return data if @card_id.nil?
+
+      data.merge(font_target: "card", card_id: @card_id)
     end
 
     def render_reading

--- a/app/javascript/controllers/font_controller.ts
+++ b/app/javascript/controllers/font_controller.ts
@@ -37,7 +37,7 @@ function saveChoice(deckId: string, choice: Choice): void {
 }
 
 export default class extends Controller<HTMLElement> {
-  static override targets = ["option"];
+  static override targets = ["card", "option"];
 
   static override values = {deckId: String};
 
@@ -46,6 +46,8 @@ export default class extends Controller<HTMLElement> {
   declare deckIdValue: string;
 
   private choice: Choice = DEFAULT_CHOICE;
+
+  private lastCardId: string | null = null;
 
   override connect(): void {
     this.applyChoice(loadChoice(this.deckIdValue));
@@ -61,10 +63,15 @@ export default class extends Controller<HTMLElement> {
   }
 
   /*
-   * Mix picks a fresh font for every card; the frame element survives Turbo
-   * frame navigations, so this fires on each turbo:frame-load.
+   * Mix picks a fresh font per card, not per Turbo frame swap: answering
+   * re-renders the frame with the same card's result, and that card must keep
+   * the font it was asked in. Card elements carry their card id, so a reroll
+   * only happens when a different card connects.
    */
-  reroll(): void {
+  cardTargetConnected(card: HTMLElement): void {
+    const {cardId} = card.dataset;
+    if (cardId === undefined || cardId === this.lastCardId) { return; }
+    this.lastCardId = cardId;
     if (this.choice !== "mix") { return; }
     this.applyFont(randomFont());
   }

--- a/app/views/studies/show.rb
+++ b/app/views/studies/show.rb
@@ -54,6 +54,7 @@ module Views
                 Components::CardFront.new(
                   text: card.front,
                   font_menu: deck.hanzi?,
+                  card_id: card.id,
                 ),
               )
 

--- a/app/views/studies/study_frame_data.rb
+++ b/app/views/studies/study_frame_data.rb
@@ -18,7 +18,6 @@ module Views
         {
           controller: "text-size font",
           font_deck_id_value: deck.id,
-          action: "turbo:frame-load->font#reroll",
         }
       end
     end

--- a/app/views/studies/update.rb
+++ b/app/views/studies/update.rb
@@ -92,6 +92,7 @@ module Views
               id: "card-question",
               reading: card.reading.to_s,
               font_menu: deck.hanzi?,
+              card_id: card.id,
             }
             render(Components::CardFront.new(**args))
             unless demo

--- a/spec/javascript/controllers/font_controller_spec.ts
+++ b/spec/javascript/controllers/font_controller_spec.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it, vi} from "vitest";
 import {
   boot,
+  buildCard,
   buildOption,
   controller,
   element,
@@ -126,21 +127,44 @@ describe("setFont defensive guards", () => {
   });
 });
 
-describe("reroll", () => {
-  it("picks a new font when mix is chosen", async () => {
+describe("a new card connecting", () => {
+  it("rerolls the font when mix is chosen", async () => {
     await boot("mix");
+    controller().cardTargetConnected(buildCard("1"));
     vi.spyOn(Math, "random").mockReturnValue(0.99);
 
-    controller().reroll();
+    controller().cardTargetConnected(buildCard("2"));
 
     expect(element().dataset.font).toBe("hand");
+  });
+
+  it("keeps the font when the same card reconnects", async () => {
+    await boot("mix");
+    controller().cardTargetConnected(buildCard("1"));
+    const asked = element().dataset.font;
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+
+    controller().cardTargetConnected(buildCard("1"));
+
+    expect(element().dataset.font).toBe(asked);
+  });
+
+  it("ignores cards without an id", async () => {
+    await boot("mix");
+    controller().cardTargetConnected(buildCard("1"));
+    const asked = element().dataset.font;
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+
+    controller().cardTargetConnected(document.createElement("div"));
+
+    expect(element().dataset.font).toBe(asked);
   });
 
   it("leaves a fixed font unchanged", async () => {
     await boot("kai");
     vi.spyOn(Math, "random").mockReturnValue(0.99);
 
-    controller().reroll();
+    controller().cardTargetConnected(buildCard("2"));
 
     expect(element().dataset.font).toBe("kai");
   });

--- a/spec/javascript/support/font_harness.ts
+++ b/spec/javascript/support/font_harness.ts
@@ -11,6 +11,14 @@ const DECK_ID = "42";
 const STORAGE_KEY = `font:${DECK_ID}`;
 const ROOT_SEL = "[data-controller='font']";
 
+function buildCard(cardId: string): HTMLElement {
+  const div = document.createElement("div");
+  div.dataset.fontTarget = "card";
+  div.dataset.cardId = cardId;
+
+  return div;
+}
+
 function buildOption(choice: Choice): HTMLButtonElement {
   const button = document.createElement("button");
   button.type = "button";
@@ -66,6 +74,7 @@ function selectEvent(choice: Choice): MouseEvent {
 
 export {
   boot,
+  buildCard,
   buildOption,
   controller,
   element,

--- a/spec/system/font_spec.rb
+++ b/spec/system/font_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe "study font" do
     expect(page).to have_css(".study-frame[data-font='song']")
   end
 
+  def pick_mix_and_read_font
+    open_card_menu
+    pick_font("mix")
+    find(".study-frame")["data-font"]
+  end
+
+  it "keeps the mixed font while answering a card" do
+    visit_hanzi_study_page
+    asked = pick_mix_and_read_font
+
+    first(".answer-button").click
+
+    expect(page).to have_css(".study-frame[data-font='#{asked}'] .answer-row")
+  end
+
   it "omits the font section on a deck without hanzi", :aggregate_failures do
     visit_latin_study_page
     open_card_menu


### PR DESCRIPTION
When a wrong answer is selected it swaps the font when re-rendering the
page. It should persist the font until the next card is displayed.
