### PR TITLE
ESLint: switch method-signature-style to "method"

### DIFF
--- a/.eslint_todo.ts
+++ b/.eslint_todo.ts
@@ -9,15 +9,6 @@ const config: Linter.Config[] = [
   // Offense count: 7
   {
     files: [
-      "app/javascript/music/reference_player.ts",
-    ],
-    rules: {
-      "@typescript-eslint/method-signature-style": "off",
-    },
-  },
-  // Offense count: 7
-  {
-    files: [
       "app/javascript/music/note_utils.ts",
     ],
     rules: {

--- a/app/javascript/music/reference_player.ts
+++ b/app/javascript/music/reference_player.ts
@@ -6,15 +6,6 @@ const FUNDAMENTAL_VOLUME = 0.4;
 const OCTAVE_VOLUME = 0.2;
 const MS_PER_SECOND = 1000;
 
-/*
- * These interfaces use method syntax rather than property syntax
- * (@typescript-eslint/method-signature-style) because method syntax
- * gives us bivariant parameter checking, which is what lets real DOM
- * AudioContext satisfy these structural interfaces. Real
- * `AudioNode.connect` takes `(dest: AudioNode | AudioParam)` —
- * narrower than our `unknown` — and only method shorthand makes the
- * relationship work without `as` casts.
- */
 interface AudioParamLike {
   setValueAtTime(value: number, when: number): void;
 }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -60,6 +60,7 @@ export default defineConfig([
       "@typescript-eslint/consistent-type-assertions":
         ["error", {assertionStyle: "never"}],
       "@typescript-eslint/explicit-member-accessibility": "off",
+      "@typescript-eslint/method-signature-style": ["error", "method"],
       "@typescript-eslint/naming-convention": "off",
       "@typescript-eslint/no-magic-numbers": "off",
       "@typescript-eslint/prefer-readonly-parameter-types": "off",


### PR DESCRIPTION
Method syntax is checked bivariantly, which is what lets the real DOM
AudioContext satisfy reference_player.ts's minimal test interfaces
(AudioNode.connect takes a narrower parameter than the interfaces'
unknown).
