### PR TITLE
Fonts: pre-warm selected font

### DIFF
--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -14,6 +14,7 @@ module Components
     include Phlex::Rails::Helpers::TurboFrameTag
 
     register_value_helper :current_user
+    register_value_helper :turbo_frame_request?
 
     def timezone_field(form)
       form.hidden_field(

--- a/app/javascript/controllers/font_controller.ts
+++ b/app/javascript/controllers/font_controller.ts
@@ -8,6 +8,14 @@ type Choice = Font | "mix";
 
 const DEFAULT_CHOICE: Choice = "hei";
 
+// Mirrors the --hanzi-font mapping in flash.css.
+const FAMILIES: {[font in Font]: string} = {
+  hand: "Ma Shan Zheng",
+  hei: "Noto Sans SC",
+  kai: "LXGW WenKai",
+  song: "Noto Serif SC",
+};
+
 function isFont(value: string | null | undefined): value is Font {
   return value === "hei" || value === "song" ||
     value === "kai" || value === "hand";
@@ -39,11 +47,13 @@ function saveChoice(deckId: string, choice: Choice): void {
 export default class extends Controller<HTMLElement> {
   static override targets = ["card", "option"];
 
-  static override values = {deckId: String};
+  static override values = {deckId: String, hanzi: String};
 
   declare optionTargets: HTMLElement[];
 
   declare deckIdValue: string;
+
+  declare hanziValue: string;
 
   private choice: Choice = DEFAULT_CHOICE;
 
@@ -85,13 +95,28 @@ export default class extends Controller<HTMLElement> {
     this.optionTargets.forEach((option) => { this.syncOption(option); });
     if (choice === "mix") {
       this.applyFont(randomFont());
+      FONTS.forEach((font) => { this.warm(font); });
     } else {
       this.applyFont(choice);
+      this.warm(choice);
     }
   }
 
   private applyFont(font: Font): void {
     this.element.dataset.font = font;
+  }
+
+  /*
+   * Ask the browser to fetch every slice of the family that the deck's
+   * characters (embedded on the initial page render) will need, so cards
+   * first paint in the correct font instead of popping in slice by slice.
+   * Slices are immutable-cached, and the browser never re-fetches a loaded
+   * face, so repeat calls cost only the range matching.
+   */
+  private warm(font: Font): void {
+    if (this.hanziValue === "") { return; }
+    document.fonts.load(`1em "${FAMILIES[font]}"`, this.hanziValue).
+      catch(() => { return null; });
   }
 
   private syncOption(option: HTMLElement): void {

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -52,10 +52,12 @@ class Deck < ApplicationRecord
 
   # Whether the deck's data_set contains Han characters on any item; gates the
   # study page's hanzi font menu.
-  def hanzi?
-    return @hanzi if defined?(@hanzi)
+  def hanzi? = hanzi_chars.present?
 
-    @hanzi = data_set.items.pluck(:text).any? { it.match?(/\p{Han}/) }
+  # The distinct Han characters across the data_set's items; the study page
+  # embeds them once so the browser can prewarm the font slices they need.
+  def hanzi_chars
+    @hanzi_chars ||= data_set.items.pluck(:text).join.scan(/\p{Han}/).uniq.join
   end
 
   def publicly_visible? = visibility == "public"

--- a/app/views/studies/show.rb
+++ b/app/views/studies/show.rb
@@ -28,7 +28,11 @@ module Views
 
           h1 { deck.name }
 
-          turbo_frame_tag("study", class: "study-frame", data: study_frame_data) do
+          turbo_frame_tag(
+            "study",
+            class: "study-frame",
+            data: study_frame_data_with_hanzi,
+          ) do
             if deck.cards.none?
               div(class: "accent-box") do
                 div(class: "accent-box__icon") { "📚" }

--- a/app/views/studies/study_frame_data.rb
+++ b/app/views/studies/study_frame_data.rb
@@ -20,6 +20,16 @@ module Views
           font_deck_id_value: deck.id,
         }
       end
+
+      # Turbo frame swaps keep the original frame element's attributes, so the
+      # hanzi prewarm payload only rides on full page loads, not on the frame
+      # navigation that fetches each next card.
+      def study_frame_data_with_hanzi
+        data = study_frame_data
+        return data if turbo_frame_request? || !deck.hanzi?
+
+        data.merge(font_hanzi_value: deck.hanzi_chars)
+      end
     end
   end
 end

--- a/spec/javascript/controllers/font_controller_spec.ts
+++ b/spec/javascript/controllers/font_controller_spec.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it, vi} from "vitest";
+import type {FontLoad} from "support/font_harness";
 import {
   boot,
   buildCard,
@@ -9,6 +10,7 @@ import {
   option,
   selectEvent,
   STORAGE_KEY,
+  stubFonts,
 } from "support/font_harness";
 
 describe("connect with empty storage", () => {
@@ -167,6 +169,65 @@ describe("a new card connecting", () => {
     controller().cardTargetConnected(buildCard("2"));
 
     expect(element().dataset.font).toBe("kai");
+  });
+});
+
+describe("prewarming", () => {
+  it("warms the chosen family with the deck's characters", async () => {
+    const fonts = stubFonts();
+
+    await boot("kai", "你好");
+
+    expect(fonts.load).toHaveBeenCalledWith("1em \"LXGW WenKai\"", "你好");
+  });
+
+  it("skips warming when no characters are embedded", async () => {
+    const fonts = stubFonts();
+
+    await boot("kai");
+
+    expect(fonts.load).not.toHaveBeenCalled();
+  });
+
+  it("warms a newly selected family", async () => {
+    const fonts = stubFonts();
+    await boot("kai", "你");
+
+    controller().setFont(selectEvent("song"));
+
+    expect(fonts.load).toHaveBeenCalledWith("1em \"Noto Serif SC\"", "你");
+  });
+
+  it("survives a failed font load", async () => {
+    stubFonts({
+      load: vi.fn<FontLoad>(async () => {
+        return Promise.reject(new Error("offline"));
+      }),
+    });
+
+    await boot("kai", "你");
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    expect(element().dataset.font).toBe("kai");
+  });
+});
+
+describe("prewarming under mix", () => {
+  it("warms every family", async () => {
+    const fonts = stubFonts();
+
+    await boot("mix", "你");
+
+    expect(fonts.load).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not warm again when a card rerolls the font", async () => {
+    const fonts = stubFonts();
+    await boot("mix", "你");
+
+    controller().cardTargetConnected(buildCard("1"));
+
+    expect(fonts.load).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/spec/javascript/support/font_harness.ts
+++ b/spec/javascript/support/font_harness.ts
@@ -1,3 +1,6 @@
+import type {Mock} from "vitest";
+import {vi} from "vitest";
+
 import {bootStimulus, getController} from "support/stimulus";
 import FontController from "controllers/font_controller";
 import {ensure} from "helpers/ensure";
@@ -10,6 +13,26 @@ const CHOICES: readonly Choice[] = ["hei", "song", "kai", "hand", "mix"];
 const DECK_ID = "42";
 const STORAGE_KEY = `font:${DECK_ID}`;
 const ROOT_SEL = "[data-controller='font']";
+
+type FontLoad = (font: string, text?: string) => Promise<unknown[]>;
+
+interface FontsStub {
+  load: Mock<FontLoad>;
+}
+
+// Jsdom has no FontFaceSet; tests exercising prewarming install this stub.
+function stubFonts(overrides: Partial<FontsStub> = {}): FontsStub {
+  const fonts: FontsStub = {
+    load: vi.fn<FontLoad>(async () => { return Promise.resolve([]); }),
+    ...overrides,
+  };
+  Object.defineProperty(document, "fonts", {
+    configurable: true,
+    value: fonts,
+  });
+
+  return fonts;
+}
 
 function buildCard(cardId: string): HTMLElement {
   const div = document.createElement("div");
@@ -29,21 +52,22 @@ function buildOption(choice: Choice): HTMLButtonElement {
   return button;
 }
 
-function setupDOM(): void {
+function setupDOM(hanzi: string): void {
   const root = document.createElement("div");
   root.dataset.controller = "font";
   root.dataset.fontDeckIdValue = DECK_ID;
+  if (hanzi !== "") { root.dataset.fontHanziValue = hanzi; }
 
   for (const choice of CHOICES) { root.appendChild(buildOption(choice)); }
 
   document.body.replaceChildren(root);
 }
 
-async function boot(storedChoice?: Choice): Promise<void> {
+async function boot(storedChoice?: Choice, hanzi = ""): Promise<void> {
   if (storedChoice !== undefined) {
     localStorage.setItem(STORAGE_KEY, storedChoice);
   }
-  setupDOM();
+  setupDOM(hanzi);
   await bootStimulus("font", FontController);
 }
 
@@ -72,6 +96,7 @@ function selectEvent(choice: Choice): MouseEvent {
   return eventTargeting("currentTarget", option(choice));
 }
 
+export type {FontLoad};
 export {
   boot,
   buildCard,
@@ -82,5 +107,6 @@ export {
   option,
   selectEvent,
   STORAGE_KEY,
+  stubFonts,
 };
 export type {Choice, Font};

--- a/spec/models/deck_spec.rb
+++ b/spec/models/deck_spec.rb
@@ -71,6 +71,23 @@ RSpec.describe Deck do
     end
   end
 
+  describe "#hanzi_chars" do
+    it "collects the distinct Han characters across items" do
+      deck = create(:deck)
+      create(:card, deck:, front: "你好", back: "hello")
+      create(:card, deck:, front: "好吗", back: "well?")
+
+      expect(deck.hanzi_chars.chars).to contain_exactly("你", "好", "吗")
+    end
+
+    it "is empty when no item contains Han characters" do
+      deck = create(:deck)
+      create(:card, deck:, front: "hola", back: "hello")
+
+      expect(deck.hanzi_chars).to eq("")
+    end
+  end
+
   describe "#publicly_visible?" do
     it "is true when visibility is public" do
       deck = create(:deck, visibility: "public")

--- a/spec/requests/studies_controller_spec.rb
+++ b/spec/requests/studies_controller_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe StudiesController do
       expect(rendered).to have_no_css(".study-frame[data-controller~='font']")
     end
 
+    it "embeds the deck's hanzi for font prewarming on full page loads" do
+      create(:card, deck:, front: "他", back: "he; him")
+      get(deck_study_path(deck))
+
+      expect(rendered).to have_css("[data-font-hanzi-value='他']")
+    end
+
+    it "omits the hanzi payload on turbo frame navigations" do
+      create(:card, deck:, front: "他", back: "he; him")
+      get(deck_study_path(deck), headers: { "Turbo-Frame" => "study" })
+
+      expect(rendered).to have_no_css("[data-font-hanzi-value]")
+    end
+
     context "when visiting on a new day" do
       before do
         card = create(:card, deck:, back: "Paris")


### PR DESCRIPTION
**What**

This makes it so that fonts get preloaded when selected or when the page
loads.

**Why**

The Mandarin fonts are sliced up into chunks on the server in order to
send the absolute minimum to the client. The browser automatically
fetches the needed chunk on demand. However, this means there is a
pretty significant amount of font pop-in while going through a Mandarin
deck. It's especially jarring when one character pops in while the one
next to it already has the correct font. This approach triggers the
browser to proactively load all of the font chunks that will be needed
for a deck to avoid pop-in.
