### PR TITLE
Fonts: don't generate woff fonts

### DIFF
--- a/bin/build_css
+++ b/bin/build_css
@@ -5,6 +5,6 @@ set -euo pipefail
 esbuild app/assets/stylesheets/application.css \
   --bundle \
   --outdir=app/assets/builds \
-  --loader:.woff=file \
+  --loader:.woff=empty \
   --loader:.woff2=file \
   "$@"


### PR DESCRIPTION
`.woff` is for super old browsers, so we can clean up our compiled
assets a bit by leaving it out.
