### PR TITLE
Test `reading` at level 2

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -15,10 +15,21 @@ class StudiesController < ApplicationController
     deck = current_user.decks.find(params.expect(:deck_id))
     result = Study.for(deck:).record_answer(params)
     increment_counters(result)
-    render_study(update_view_class(deck), deck:, result:)
+    if result.reading_passed?
+      render_translation_stage(deck, result.card)
+    else
+      render_study(update_view_class(deck), deck:, result:)
+    end
   end
 
   private
+
+  # A passed reading stage re-renders the question view pinned to the same
+  # card, now asking for the translation.
+  def render_translation_stage(deck, card)
+    study = Study.for(deck:, card_id: card.id)
+    render_study(show_view_class(deck), deck:, study:)
+  end
 
   def show_view_class(deck)
     deck.music? ? Views::Studies::MusicShow : Views::Studies::Show

--- a/app/domain/music_study.rb
+++ b/app/domain/music_study.rb
@@ -3,7 +3,7 @@
 class MusicStudy < Study
   attr_accessor :next_window
 
-  def initialize(deck:, exclude_card_id: nil)
+  def initialize(deck:, exclude_card_id: nil, card_id: nil)
     super
     self.next_window = pick_window
   end

--- a/app/domain/study.rb
+++ b/app/domain/study.rb
@@ -3,6 +3,7 @@
 class Study
   ACTIVE_CARD_THRESHOLD = 20
   FUZZY_FIND_LEVEL = 3
+  READING_LEVEL = 2
   Result =
     Data.define(
       :card,
@@ -13,23 +14,32 @@ class Study
       :possible_answers,
       :card_completed,
       :level_completed,
+      :reading_passed,
     ) do
+      def initialize(reading_passed: false, **rest) = super
       def correct? = correct
       def card_completed? = card_completed
       def level_completed? = level_completed
+      def reading_passed? = reading_passed
     end
 
-  attr_accessor :deck, :next_card
+  attr_accessor :deck, :next_card, :reading_confirmed
 
-  def self.for(deck:, exclude_card_id: nil)
+  def self.for(deck:, exclude_card_id: nil, card_id: nil)
     klass = deck.music? ? MusicStudy : self
-    klass.new(deck:, exclude_card_id:)
+    klass.new(deck:, exclude_card_id:, card_id:)
   end
 
-  def initialize(deck:, exclude_card_id: nil)
+  # A card_id pins the study to that card's translation question - the render
+  # that follows a passed reading stage.
+  def initialize(deck:, exclude_card_id: nil, card_id: nil)
     self.deck = deck
-    self.next_card = pick_next_card(exclude_card_id:)
+    self.reading_confirmed = !card_id.nil?
+    self.next_card =
+      card_id ? deck.cards.find(card_id) : pick_next_card(exclude_card_id:)
   end
+
+  def reading_confirmed? = reading_confirmed
 
   def active_card_threshold
     (2**(deck.level - 1)) * ACTIVE_CARD_THRESHOLD
@@ -41,13 +51,22 @@ class Study
   end
 
   def presentation_mode
-    deck.level >= FUZZY_FIND_LEVEL ? :fuzzy_find : :multiple_choice
+    if reading_stage?
+      :reading
+    elsif deck.level >= FUZZY_FIND_LEVEL
+      :fuzzy_find
+    else
+      :multiple_choice
+    end
   end
 
   def record_answer(params)
     permitted =
-      params.expect(answer: [:card_id, :answer, { possible_answers: [] }])
-    answer_card(**permitted.to_h.symbolize_keys)
+      params
+        .expect(answer: [:card_id, :answer, :stage, { possible_answers: [] }])
+    answer = permitted.to_h.symbolize_keys
+    stage = answer.delete(:stage)
+    stage == "reading" ? answer_reading(**answer) : answer_card(**answer)
   end
 
   def possible_answers
@@ -55,8 +74,33 @@ class Study
 
     case presentation_mode
     when :fuzzy_find then fuzzy_answers
+    when :reading then reading_answers
     else multiple_choice_answers
     end
+  end
+
+  # The reading stage gates the translation question but never scores it: a
+  # pass writes nothing (answer_card does the bookkeeping), a miss resets the
+  # streak without recording a translation distractor.
+  def answer_reading(card_id:, answer:, possible_answers: [])
+    card = deck.cards.find(card_id)
+    correct = card.reading == answer
+    unless correct
+      card.view_count += 1
+      card.correct_streak = 0
+      card.save!
+    end
+    Result.new(
+      card:,
+      correct:,
+      correct_answer: card.reading,
+      question: card.front,
+      selected_answer: answer,
+      possible_answers: [*possible_answers, card.reading].uniq,
+      card_completed: false,
+      level_completed: false,
+      reading_passed: correct,
+    )
   end
 
   def answer_card(card_id:, answer:, possible_answers: [])
@@ -100,6 +144,52 @@ class Study
   end
 
   private
+
+  def reading_stage?
+    !reading_confirmed &&
+      deck.level == READING_LEVEL &&
+      deck.anchor_side == "Front" &&
+      next_card&.reading.present?
+  end
+
+  # Decoys come from the siblings whose front character count is closest to
+  # the prompt's (random tiebreak): a learner predicts the phoneme count from
+  # the prompt, so a wrong-count option is a free elimination. Two slots
+  # prefer same-count siblings sharing the prompt's first or last character -
+  # those can't be eliminated by knowing that one character's reading.
+  def reading_answers
+    front = next_card.front
+    pool = sibling_pool(next_card.reading)
+    anchored = shared_character_decoys(pool, front)
+    fillers = count_ranked(pool, front).map(&:last).uniq - anchored
+    decoys = [*anchored, *fillers].first(4)
+    [*decoys, next_card.reading].shuffle
+  end
+
+  # A slot takes a random sibling that shares its end character and matches
+  # the prompt's character count exactly, so it blends in with the
+  # count-matched fillers. (A single-character prompt can never anchor: a
+  # same-count sibling sharing its character would be the prompt itself.)
+  def shared_character_decoys(pool, front)
+    peers = pool.select { |text, _| text.length == front.length }
+    slots = [
+      peers.select { |text, _| text.start_with?(front.chars.first) },
+      peers.select { |text, _| text.end_with?(front.chars.last) },
+    ]
+    slots.filter_map { |pairs| pairs.sample&.last }.uniq
+  end
+
+  def count_ranked(pairs, front)
+    pairs.sort_by { |text, _| [(text.length - front.length).abs, rand] }
+  end
+
+  # Sibling (front, reading) pairs with a reading; homophones of the correct
+  # reading are excluded so a decoy can't also be right.
+  def sibling_pool(correct)
+    siblings = deck.cards.where.not(id: next_card.id)
+    pairs = siblings.joins(:item).pluck("items.text", "items.reading")
+    pairs.select { |_, reading| reading.present? && reading != correct }
+  end
 
   def multiple_choice_answers
     distractors = next_card.distractors.sample(4)

--- a/app/views/studies/show.rb
+++ b/app/views/studies/show.rb
@@ -57,6 +57,9 @@ module Views
               render(
                 Components::CardFront.new(
                   text: card.front,
+                  # A confirmed reading stays visible while the translation
+                  # stage is answered.
+                  reading: (card.reading if study.reading_confirmed?),
                   font_menu: deck.mandarin?,
                   card_id: card.id,
                 ),
@@ -75,20 +78,30 @@ module Views
 
       def render_active_card(card)
         answers = study.possible_answers
-        if study.presentation_mode == :fuzzy_find
+        case study.presentation_mode
+        when :fuzzy_find
           render(Components::FuzzyFindAnswers.new(deck:, card:, answers:))
+        when :reading
+          p(class: "keyboard-hint") { "Pick the reading" }
+          render_answers(card, answers, stage: "reading")
+          p(class: "keyboard-hint") { "Press 1-5 to answer" }
         else
           render_answers(card, answers)
           p(class: "keyboard-hint") { "Press 1-5 to answer" }
         end
       end
 
-      def render_answers(card, answers)
+      def render_answers(card, answers, stage: nil)
         ol(class: "study-answers-grid") do
           answers.each_with_index do |answer, index|
             li do
               params = {
-                answer: { answer:, card_id: card.id, possible_answers: answers },
+                answer: {
+                  answer:,
+                  card_id: card.id,
+                  possible_answers: answers,
+                  stage:,
+                }.compact,
               }
               data = { hotkeys_target: "click", hotkey: (index + 1).to_s }
               button_to(

--- a/spec/domain/study_spec.rb
+++ b/spec/domain/study_spec.rb
@@ -95,6 +95,16 @@ RSpec.describe Study do
 
       expect(study.next_card).to eq(excluded)
     end
+
+    it "pins next_card to the given card_id" do
+      deck = create(:deck)
+      card = create(:card, deck:)
+      create(:card, deck:)
+
+      study = described_class.new(deck:, card_id: card.id)
+
+      expect(study.next_card).to eq(card)
+    end
   end
 
   describe "#presentation_mode" do
@@ -115,6 +125,58 @@ RSpec.describe Study do
       deck = create(:deck, level: described_class::FUZZY_FIND_LEVEL + 1)
 
       expect(described_class.new(deck:).presentation_mode).to eq(:fuzzy_find)
+    end
+
+    context "when the deck is at the reading level" do
+      def reading_level_deck
+        create(:deck, level: described_class::READING_LEVEL)
+      end
+
+      it "returns :reading when the next card has a reading" do
+        deck = reading_level_deck
+        create(:card, deck:, reading: "liǎng")
+
+        expect(described_class.new(deck:).presentation_mode).to eq(:reading)
+      end
+
+      it "returns :multiple_choice when the next card has no reading" do
+        deck = reading_level_deck
+        create(:card, deck:)
+
+        expect(described_class.new(deck:).presentation_mode)
+          .to eq(:multiple_choice)
+      end
+
+      it "returns :multiple_choice when pinned to a card by card_id" do
+        deck = reading_level_deck
+        card = create(:card, deck:, reading: "liǎng")
+
+        study = described_class.new(deck:, card_id: card.id)
+
+        expect(study.presentation_mode).to eq(:multiple_choice)
+      end
+
+      def reverse_deck_with_reading
+        source = create(:deck)
+        create(:card, deck: source, front: "两", back: "two", reading: "liǎng")
+        reverse = Decks::CreateReverse.call(source:).record
+        reverse.tap { |deck| deck.update!(level: Study::READING_LEVEL) }
+      end
+
+      it "returns :multiple_choice on a reverse deck" do
+        reverse = reverse_deck_with_reading
+
+        expect(described_class.new(deck: reverse).presentation_mode)
+          .to eq(:multiple_choice)
+      end
+    end
+
+    it "returns :multiple_choice below the reading level" do
+      deck = create(:deck, level: described_class::READING_LEVEL - 1)
+      create(:card, deck:, reading: "liǎng")
+
+      expect(described_class.new(deck:).presentation_mode)
+        .to eq(:multiple_choice)
     end
   end
 
@@ -222,6 +284,136 @@ RSpec.describe Study do
       end
     end
 
+    context "when in reading mode" do
+      # A reading-level deck holding the prompt card the study will pick.
+      def deck_with_prompt(front:, reading:)
+        deck = create(:deck, level: Study::READING_LEVEL)
+        create(:card, deck:, front:, reading:)
+        deck
+      end
+
+      it "includes the card's reading" do
+        deck = deck_with_prompt(front: "两", reading: "liǎng")
+
+        expect(described_class.new(deck:).possible_answers).to include("liǎng")
+      end
+
+      it "uses sibling readings as decoys" do
+        deck = deck_with_prompt(front: "两", reading: "liǎng")
+        create(:card, :done, deck:, reading: "sān")
+
+        expect(described_class.new(deck:).possible_answers)
+          .to contain_exactly("liǎng", "sān")
+      end
+
+      it "excludes sibling readings equal to the card's own" do
+        deck = deck_with_prompt(front: "是", reading: "shì")
+        create(:card, :done, deck:, reading: "shì")
+
+        expect(described_class.new(deck:).possible_answers).to eq(["shì"])
+      end
+
+      it "skips siblings without a reading" do
+        deck = deck_with_prompt(front: "两", reading: "liǎng")
+        create(:card, :done, deck:)
+
+        expect(described_class.new(deck:).possible_answers).to eq(["liǎng"])
+      end
+
+      it "deduplicates repeated sibling readings" do
+        deck = deck_with_prompt(front: "两", reading: "liǎng")
+        create(:card, :done, deck:, reading: "sān")
+        create(:card, :done, deck:, reading: "sān")
+
+        answers = described_class.new(deck:).possible_answers
+
+        expect(answers.tally.values).to all(eq(1))
+      end
+
+      def create_siblings(deck, readings)
+        readings.each { |reading| create(:card, :done, deck:, reading:) }
+      end
+
+      it "prefers decoys whose front matches the prompt's character count" do
+        deck = deck_with_prompt(front: "学生", reading: "abcd")
+        create(:card, :done, deck:, front: "九十百千万", reading: "uvwx")
+        create_filler_siblings(deck)
+
+        expect(described_class.new(deck:).possible_answers)
+          .not_to include("uvwx")
+      end
+
+      it "offers at most five options" do
+        deck = deck_with_prompt(front: "妈", reading: "mā")
+        create_siblings(deck, ["bà", "gē", "dì", "yī", "èr"])
+
+        expect(described_class.new(deck:).possible_answers.size).to eq(5)
+      end
+
+      def create_reading_siblings(deck, pairs)
+        pairs.each do |front, reading|
+          create(:card, :done, deck:, front:, reading:)
+        end
+      end
+
+      # Four filler siblings with two-character fronts that share no character
+      # with the prompts below.
+      def create_filler_siblings(deck)
+        fillers =
+          [["一二", "efgh"], ["三四", "ijkl"], ["五六", "mnop"], ["七八", "qrst"]]
+        create_reading_siblings(deck, fillers)
+      end
+
+      # The single-character version of the fillers above.
+      def create_single_char_fillers(deck)
+        pairs = [["一", "efgh"], ["二", "ijkl"], ["三", "mnop"], ["四", "qrst"]]
+        create_reading_siblings(deck, pairs)
+      end
+
+      it "anchors a decoy on the prompt's first character" do
+        deck = deck_with_prompt(front: "学生", reading: "abcd")
+        create(:card, :done, deck:, front: "学校", reading: "abzzzz")
+        create_filler_siblings(deck)
+
+        expect(described_class.new(deck:).possible_answers).to include("abzzzz")
+      end
+
+      it "anchors a decoy on the prompt's last character" do
+        deck = deck_with_prompt(front: "学生", reading: "abcd")
+        create(:card, :done, deck:, front: "先生", reading: "zzzzcd")
+        create_filler_siblings(deck)
+
+        expect(described_class.new(deck:).possible_answers).to include("zzzzcd")
+      end
+
+      it "does not anchor decoys for a single-character prompt" do
+        deck = deck_with_prompt(front: "人", reading: "abcd")
+        create(:card, :done, deck:, front: "人们", reading: "abzzzz")
+        create_single_char_fillers(deck)
+
+        expect(described_class.new(deck:).possible_answers)
+          .not_to include("abzzzz")
+      end
+
+      it "does not anchor a shared-character sibling of a different count" do
+        deck = deck_with_prompt(front: "学生", reading: "abcd")
+        create(:card, :done, deck:, front: "学校图书馆", reading: "abzzzz")
+        create_filler_siblings(deck)
+
+        expect(described_class.new(deck:).possible_answers)
+          .not_to include("abzzzz")
+      end
+
+      it "does not duplicate a sibling matching both ends of the prompt" do
+        deck = deck_with_prompt(front: "人中人", reading: "aa")
+        create(:card, :done, deck:, front: "人间人", reading: "bb")
+
+        answers = described_class.new(deck:).possible_answers
+
+        expect(answers.tally.values).to all(eq(1))
+      end
+    end
+
     context "when deck distractor_pool is 'preset'" do
       it "uses only the card's own distractors" do
         deck = create(:deck, distractor_pool: "preset")
@@ -251,6 +443,112 @@ RSpec.describe Study do
         answers = described_class.new(deck:).possible_answers
 
         expect(answers).to eq(["Paris"])
+      end
+    end
+  end
+
+  describe "#answer_reading" do
+    def reading_card(**attrs)
+      deck = create(:deck, level: Study::READING_LEVEL)
+      create(:card, deck:, reading: "liǎng", **attrs)
+    end
+
+    def answer_reading(card:, answer:)
+      described_class.new(deck: card.deck)
+        .answer_reading(card_id: card.id, answer:)
+    end
+
+    context "when the reading is correct" do
+      it "returns reading_passed true" do
+        card = reading_card
+
+        result = answer_reading(card:, answer: "liǎng")
+
+        expect(result.reading_passed?).to be(true)
+      end
+
+      it "returns correct true" do
+        card = reading_card
+
+        result = answer_reading(card:, answer: "liǎng")
+
+        expect(result.correct?).to be(true)
+      end
+
+      it "does not change the view count" do
+        card = reading_card
+
+        expect { answer_reading(card:, answer: "liǎng") }
+          .to not_change_record(card, :view_count)
+      end
+
+      it "does not change the correct streak" do
+        card = reading_card(correct_streak: 1)
+
+        expect { answer_reading(card:, answer: "liǎng") }
+          .to not_change_record(card, :correct_streak)
+      end
+
+      it "does not record a distractor" do
+        card = reading_card
+
+        expect { answer_reading(card:, answer: "liǎng") }
+          .to(not_change { card.reload.distractors })
+      end
+    end
+
+    context "when the reading is wrong" do
+      it "returns reading_passed false" do
+        card = reading_card
+
+        result = answer_reading(card:, answer: "sān")
+
+        expect(result.reading_passed?).to be(false)
+      end
+
+      it "returns correct false" do
+        card = reading_card
+
+        result = answer_reading(card:, answer: "sān")
+
+        expect(result.correct?).to be(false)
+      end
+
+      it "resets the correct streak" do
+        card = reading_card(correct_streak: 1)
+
+        expect { answer_reading(card:, answer: "sān") }
+          .to change_record(card, :correct_streak).from(1).to(0)
+      end
+
+      it "increments the view count" do
+        card = reading_card(view_count: 0)
+
+        expect { answer_reading(card:, answer: "sān") }
+          .to change_record(card, :view_count).from(0).to(1)
+      end
+
+      it "does not record the wrong reading as a distractor" do
+        card = reading_card
+
+        expect { answer_reading(card:, answer: "sān") }
+          .to(not_change { card.reload.distractors })
+      end
+
+      it "returns the reading as the correct answer" do
+        card = reading_card
+
+        result = answer_reading(card:, answer: "sān")
+
+        expect(result.correct_answer).to eq("liǎng")
+      end
+
+      it "includes the reading in result possible_answers" do
+        card = reading_card
+
+        result = answer_reading(card:, answer: "sān")
+
+        expect(result.possible_answers).to include("liǎng")
       end
     end
   end

--- a/spec/requests/studies_controller_spec.rb
+++ b/spec/requests/studies_controller_spec.rb
@@ -544,6 +544,118 @@ RSpec.describe StudiesController do
     end
   end
 
+  describe "reading stage" do
+    def reading_card(**attrs)
+      deck = create(:deck, level: 2)
+      create(:card, deck:, reading: "liǎng", **attrs)
+    end
+
+    def submit_reading(card:, answer:)
+      answer_params = {
+        card_id: card.id,
+        answer:,
+        stage: "reading",
+        possible_answers: ["liǎng", "sān"],
+      }
+      patch(deck_study_path(card.deck), params: { answer: answer_params })
+    end
+
+    it "asks for the reading first at level 2" do
+      card = reading_card
+      get(deck_study_path(card.deck))
+
+      expect(rendered).to have_text("Pick the reading")
+    end
+
+    it "offers the reading as an answer option" do
+      card = reading_card
+      get(deck_study_path(card.deck))
+
+      expect(rendered).to have_css(".answer-button", text: "liǎng")
+    end
+
+    it "skips the gate when the card has no reading" do
+      card = reading_card(reading: nil)
+      get(deck_study_path(card.deck))
+
+      expect(rendered).to have_no_text("Pick the reading")
+    end
+
+    context "when the reading is answered correctly" do
+      it "renders the translation question for the same card" do
+        card = reading_card(front: "两", back: "two")
+        submit_reading(card:, answer: "liǎng")
+
+        expect(rendered).to have_css(".card-front", text: "两")
+      end
+
+      it "offers the translation as an answer option" do
+        card = reading_card(back: "two")
+        submit_reading(card:, answer: "liǎng")
+
+        expect(rendered).to have_css(".answer-button", text: "two")
+      end
+
+      it "shows the confirmed reading under the character" do
+        card = reading_card(back: "two")
+        submit_reading(card:, answer: "liǎng")
+
+        expect(rendered).to have_css("#card-reading", text: "liǎng")
+      end
+
+      it "no longer asks for the reading" do
+        card = reading_card(back: "two")
+        submit_reading(card:, answer: "liǎng")
+
+        expect(rendered).to have_no_text("Pick the reading")
+      end
+
+      it "does not change the correct streak" do
+        card = reading_card(correct_streak: 1)
+
+        expect { submit_reading(card:, answer: "liǎng") }
+          .to not_change_record(card, :correct_streak)
+      end
+    end
+
+    context "when the reading is answered incorrectly" do
+      it "reveals the correct reading" do
+        card = reading_card
+        submit_reading(card:, answer: "sān")
+
+        expect(rendered).to have_css(".answer-correct", text: "liǎng")
+      end
+
+      it "marks the wrong reading" do
+        card = reading_card
+        submit_reading(card:, answer: "sān")
+
+        expect(rendered).to have_css(".answer-incorrect", text: "sān")
+      end
+
+      it "resets the correct streak" do
+        card = reading_card(correct_streak: 1)
+
+        expect { submit_reading(card:, answer: "sān") }
+          .to change_record(card, :correct_streak).from(1).to(0)
+      end
+
+      it "does not record the wrong reading as a distractor" do
+        card = reading_card
+
+        expect { submit_reading(card:, answer: "sān") }
+          .to(not_change { card.reload.distractors })
+      end
+
+      it "shows the next card link" do
+        card = reading_card
+        submit_reading(card:, answer: "sān")
+
+        expect(rendered).to have_link("Next Card")
+      end
+    end
+  end
+
   describe "reading" do
     it "renders the card reading after answering" do
       card = create(:card, deck:, back: "two", reading: "liǎng")

--- a/spec/system/studies_spec.rb
+++ b/spec/system/studies_spec.rb
@@ -148,4 +148,39 @@ RSpec.describe "studying a deck" do
       expect(page).to have_text("No matches")
     end
   end
+
+  context "when the deck is at the reading level" do
+    def visit_reading_deck
+      deck = create(:deck, user: default_user, level: Study::READING_LEVEL)
+      create(:card, deck:, front: "两", back: "two", reading: "liǎng")
+      create(:card, :done, deck:, back: "three", reading: "sān")
+      sign_in(default_user)
+      visit(deck_study_path(deck))
+    end
+
+    it "asks the translation of the same card once the reading is picked" do
+      visit_reading_deck
+      expect(page).to have_text(/pick the reading/i)
+
+      click_on("liǎng")
+
+      expect(page).to have_css(".card-front", text: "两")
+      expect(page).to have_css("#card-reading", text: "liǎng")
+    end
+
+    it "completes the card through both stages" do
+      visit_reading_deck
+      click_on("liǎng")
+      click_on("two")
+
+      expect(page).to have_css("#correct-answer-text", text: "two")
+    end
+
+    it "reveals the correct reading after a miss" do
+      visit_reading_deck
+      click_on("sān")
+
+      expect(page).to have_css(".answer-correct", text: "liǎng")
+    end
+  end
 end


### PR DESCRIPTION
This updates the study logic to have two steps once the user reaches
level 2 when there is a `reading` present. It first tests the user's on
the reading itself, then the back of the card if they get the reading
right.
