### PR TITLE
Organization: remove `paths` table

### DIFF
--- a/db/migrate/20260710000000_drop_paths.rb
+++ b/db/migrate/20260710000000_drop_paths.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Paths (ordered deck sequences) never got built beyond this schema; the
+# Topics design supersedes it. See NOTES.md.
+class DropPaths < ActiveRecord::Migration[8.1]
+  def up
+    safety_assured do
+      remove_column(:decks, :path_id)
+      remove_column(:decks, :path_position)
+      drop_table(:paths)
+    end
+  end
+
+  def down
+    create_table(:paths) do |t|
+      t.string(:name, null: false)
+      t.references(:user, null: false, foreign_key: true)
+      t.timestamps
+      t.index([:user_id, :name], unique: true)
+    end
+    add_reference(:decks, :path, foreign_key: true)
+    add_column(:decks, :path_position, :integer)
+    add_index(:decks, [:path_id, :path_position], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_09_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_10_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -58,16 +58,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_000000) do
     t.string "distractor_pool", null: false
     t.integer "level", null: false
     t.boolean "ordered", default: false, null: false
-    t.bigint "path_id"
-    t.integer "path_position"
     t.string "share_token"
     t.integer "study_goal", null: false
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.string "visibility", default: "private", null: false
     t.index ["data_set_id"], name: "index_decks_on_data_set_id"
-    t.index ["path_id", "path_position"], name: "index_decks_on_path_id_and_path_position", unique: true
-    t.index ["path_id"], name: "index_decks_on_path_id"
     t.index ["share_token"], name: "index_decks_on_share_token", unique: true
     t.index ["type"], name: "index_decks_on_type"
     t.index ["visibility"], name: "index_decks_on_visibility"
@@ -104,15 +100,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_000000) do
     t.index ["paired_item_id"], name: "index_pairings_on_paired_item_id"
   end
 
-  create_table "paths", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "name", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.index ["user_id", "name"], name: "index_paths_on_user_id_and_name", unique: true
-    t.index ["user_id"], name: "index_paths_on_user_id"
-  end
-
   create_table "subscriptions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "creem_subscription_id"
@@ -147,12 +134,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_09_000000) do
   add_foreign_key "cards", "items", on_delete: :cascade
   add_foreign_key "data_sets", "users", on_delete: :cascade
   add_foreign_key "decks", "data_sets", on_delete: :cascade
-  add_foreign_key "decks", "paths"
   add_foreign_key "item_distractors", "items", column: "distractor_item_id", on_delete: :cascade
   add_foreign_key "item_distractors", "items", on_delete: :cascade
   add_foreign_key "items", "data_sets", on_delete: :cascade
   add_foreign_key "pairings", "items", column: "paired_item_id", on_delete: :cascade
   add_foreign_key "pairings", "items", on_delete: :cascade
-  add_foreign_key "paths", "users"
   add_foreign_key "subscriptions", "users"
 end


### PR DESCRIPTION
**Why**

We're going to be taking a different _path_ for deck organization.
