### PR TITLE
DataSets: rename deck types

### DIFF
--- a/app/actions/decks/create.rb
+++ b/app/actions/decks/create.rb
@@ -8,8 +8,9 @@ module Decks
 
     def call(user:, name:, cards_csv:, language: nil)
       language = language.presence
+      deck_class = language ? ReadingDeck : BasicDeck
       data_set_class = language ? LanguageDataSet : BasicDataSet
-      deck = TextDeck.new(
+      deck = deck_class.new(
         study_goal: user.study_goal,
         data_set: data_set_class.new(user:, name:, language:),
       )

--- a/app/actions/decks/create_reverse.rb
+++ b/app/actions/decks/create_reverse.rb
@@ -25,7 +25,7 @@ module Decks
     end
 
     def build_deck(source)
-      ReverseTextDeck.new(
+      WritingDeck.new(
         study_goal: source.study_goal,
         distractor_pool: "category",
         data_set: source.data_set,

--- a/app/controllers/decks_controller.rb
+++ b/app/controllers/decks_controller.rb
@@ -19,7 +19,7 @@ class DecksController < ApplicationController
   end
 
   def new
-    deck = TextDeck.new(data_set: BasicDataSet.new)
+    deck = BasicDeck.new(data_set: BasicDataSet.new)
     render(Views::Decks::New.new(deck:))
   end
 
@@ -62,7 +62,7 @@ class DecksController < ApplicationController
   end
 
   def language_missing_error
-    deck = TextDeck.new(data_set: BasicDataSet.new(name: deck_params[:name]))
+    deck = BasicDeck.new(data_set: BasicDataSet.new(name: deck_params[:name]))
     deck.errors.add(:base, "Please select a language")
     deck_create_failed(deck)
   end

--- a/app/controllers/replacements_controller.rb
+++ b/app/controllers/replacements_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReplacementsController < ApplicationController
-  before_action(:ensure_text_deck)
+  before_action(:ensure_replaceable_deck)
 
   def new
     render(Views::Decks::Replacements::New.new(deck:))
@@ -39,8 +39,8 @@ class ReplacementsController < ApplicationController
     params.expect(replacement: [:cards_csv]).to_h.symbolize_keys
   end
 
-  def ensure_text_deck
-    return if deck.instance_of?(TextDeck)
+  def ensure_replaceable_deck
+    return if deck.replaceable?
 
     flash[:error] = t("replacements.unsupported")
     redirect_to(deck_path(deck))

--- a/app/models/basic_data_set.rb
+++ b/app/models/basic_data_set.rb
@@ -2,4 +2,6 @@
 
 class BasicDataSet < DataSet
   validates :language, absence: true
+
+  def deck_classes = [BasicDeck]
 end

--- a/app/models/basic_deck.rb
+++ b/app/models/basic_deck.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Plain forward flashcards over a BasicDataSet: no language features, no
+# reverse form.
+class BasicDeck < Deck
+  def self.model_name
+    Deck.model_name
+  end
+
+  def replaceable? = true
+end

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -8,4 +8,8 @@ class DataSet < ApplicationRecord
   has_many :decks, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { scope: :user_id }
+
+  # The deck classes that can be built over this data_set; each subclass
+  # declares its own.
+  def deck_classes = []
 end

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -18,6 +18,7 @@ class Deck < ApplicationRecord
   validates :study_goal,
             numericality: { greater_than_or_equal_to: 1, only_integer: true }
   validate(:data_set_name_valid, if: -> { data_set&.new_record? })
+  validate(:type_allowed_by_data_set)
 
   scope :ordered, -> { joins(:data_set).order("data_sets.name") }
   scope :publicly_visible, -> { where(visibility: "public") }
@@ -37,10 +38,14 @@ class Deck < ApplicationRecord
 
   def reversible? = false
 
+  # Whether the deck's content can be replaced from a fresh CSV; only the
+  # forward text decks support it.
+  def replaceable? = false
+
   # Whether a reverse deck already exists over this deck's data_set (one per
   # source); used to guard creation and hide the create button.
   def reverse_present?
-    data_set.present? && data_set.decks.exists?(type: "ReverseTextDeck")
+    data_set.present? && data_set.decks.exists?(type: "WritingDeck")
   end
 
   # Cards whose studied answer carries the given category, for category-pool
@@ -50,14 +55,8 @@ class Deck < ApplicationRecord
     cards.joins(:item).where(items: { category: })
   end
 
-  # Gates the study page's Mandarin font menu.
-  def mandarin? = language == "zh"
-
-  # The distinct Han characters across the data_set's items; the study page
-  # embeds them once so the browser can prewarm the font slices they need.
-  def hanzi_chars
-    @hanzi_chars ||= data_set.items.pluck(:text).join.scan(/\p{Han}/).uniq.join
-  end
+  # Gates the study page's Mandarin font menu; only language decks can be.
+  def mandarin? = false
 
   def publicly_visible? = visibility == "public"
 
@@ -75,5 +74,11 @@ class Deck < ApplicationRecord
 
   def data_set_name_valid
     errors.merge!(data_set.errors) unless data_set.valid?
+  end
+
+  def type_allowed_by_data_set
+    return if data_set.nil? || data_set.deck_classes.include?(self.class)
+
+    errors.add(:type, "can't be built on a #{data_set.class.name}")
   end
 end

--- a/app/models/language_data_set.rb
+++ b/app/models/language_data_set.rb
@@ -37,4 +37,6 @@ class LanguageDataSet < DataSet
   ].freeze
 
   validates :language, presence: true, inclusion: { in: LANGUAGES.keys }
+
+  def deck_classes = [ReadingDeck, WritingDeck]
 end

--- a/app/models/language_deck.rb
+++ b/app/models/language_deck.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Shared behavior for decks over a LanguageDataSet: one class per language
+# skill (Reading, Writing; someday Listening, Speaking). Never instantiated
+# directly.
+class LanguageDeck < Deck
+  def self.model_name
+    Deck.model_name
+  end
+
+  def mandarin? = language == "zh"
+
+  # The distinct Han characters across the data_set's items; the study page
+  # embeds them once so the browser can prewarm the font slices they need.
+  def hanzi_chars
+    @hanzi_chars ||= data_set.items.pluck(:text).join.scan(/\p{Han}/).uniq.join
+  end
+end

--- a/app/models/music_data_set.rb
+++ b/app/models/music_data_set.rb
@@ -2,4 +2,6 @@
 
 class MusicDataSet < DataSet
   validates :language, absence: true
+
+  def deck_classes = [MusicDeck]
 end

--- a/app/models/reading_deck.rb
+++ b/app/models/reading_deck.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# The forward study of a language data_set: recognize the target-language
+# prompt and recall its meaning.
+class ReadingDeck < LanguageDeck
+  def reversible? = true
+
+  def replaceable? = true
+end

--- a/app/models/text_deck.rb
+++ b/app/models/text_deck.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class TextDeck < Deck
-  def self.model_name
-    Deck.model_name
-  end
-
-  def reversible? = true
-end

--- a/app/models/writing_deck.rb
+++ b/app/models/writing_deck.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-# A reverse deck studies an existing data_set in the opposite direction: the
-# Back items become prompts and their paired Front items the answers. It shares
-# the source deck's data_set (no re-upload); only the reading direction differs.
-class ReverseTextDeck < TextDeck
+# The reverse study of a language data_set: given a meaning, recall the
+# target-language word and identify its written form. The Back items become
+# prompts and their paired Front items the answers; it shares the source
+# deck's data_set (no re-upload), only the direction differs.
+class WritingDeck < LanguageDeck
   def name = "#{data_set.name} (reversed)"
 
   def card_type = "ReverseTextCard"
@@ -11,9 +12,6 @@ class ReverseTextDeck < TextDeck
   def anchor_side = "Back"
 
   def anchor_pairing_column = :paired_item_id
-
-  # A reverse of a reverse would just be the forward deck again.
-  def reversible? = false
 
   # The category lives on the answer (Front) item, so reach it through the
   # pairing: Front items in the category -> their paired Back items -> cards.

--- a/app/views/decks/show.rb
+++ b/app/views/decks/show.rb
@@ -23,7 +23,7 @@ module Views
 
         render_share_section
         render(Components::CatalogToggleButton.new(deck:)) if admin_owner?
-        render_replace_link if deck.instance_of?(TextDeck)
+        render_replace_link if deck.replaceable?
         render_reverse_button if deck.reversible? && !deck.reverse_present?
 
         render_cards_table if deck.cards.any?

--- a/db/migrate/20260711000000_rename_deck_types.rb
+++ b/db/migrate/20260711000000_rename_deck_types.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Deck classes renamed to match their UI representation (see NOTES.md):
+# forward decks split by their data_set's type into Reading (language) and
+# Basic, and the reverse deck becomes Writing.
+class RenameDeckTypes < ActiveRecord::Migration[8.1]
+  def up
+    safety_assured do
+      execute(<<~SQL.squish)
+        UPDATE decks SET type = CASE
+          WHEN type = 'ReverseTextDeck' THEN 'WritingDeck'
+          WHEN type = 'TextDeck' AND EXISTS (
+            SELECT 1 FROM data_sets
+            WHERE data_sets.id = decks.data_set_id
+              AND data_sets.type = 'LanguageDataSet'
+          ) THEN 'ReadingDeck'
+          WHEN type = 'TextDeck' THEN 'BasicDeck'
+          ELSE type
+        END
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute(<<~SQL.squish)
+        UPDATE decks SET type = CASE
+          WHEN type = 'WritingDeck' THEN 'ReverseTextDeck'
+          WHEN type IN ('ReadingDeck', 'BasicDeck') THEN 'TextDeck'
+          ELSE type
+        END
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_10_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_11_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/actions/catalog/copy_deck_spec.rb
+++ b/spec/actions/catalog/copy_deck_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe Catalog::CopyDeck do
     end
 
     it "copies the language from the source data_set" do
-      source = create(:deck, visibility: "public", language: "zh")
+      source = create(:reading_deck, visibility: "public")
       result = described_class.call(user: create(:user), deck: source)
 
       expect(result.record.data_set.language).to eq("zh")
     end
 
     it "copies the data_set type from the source" do
-      source = create(:deck, visibility: "public", language: "zh")
+      source = create(:reading_deck, visibility: "public")
       result = described_class.call(user: create(:user), deck: source)
 
       expect(result.record.data_set).to be_a(LanguageDataSet)

--- a/spec/actions/data_sets/projection_spec.rb
+++ b/spec/actions/data_sets/projection_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe DataSets::Projection do
 
   describe "reverse-deck sync" do
     def with_reverse(forward_cards)
-      fwd = create(:deck)
+      fwd = create(:reading_deck)
       forward_cards.each { |attrs| create(:card, deck: fwd, **attrs) }
       [fwd, Decks::CreateReverse.call(source: fwd).record]
     end

--- a/spec/actions/decks/create_reverse_spec.rb
+++ b/spec/actions/decks/create_reverse_spec.rb
@@ -4,16 +4,16 @@ require "rails_helper"
 
 RSpec.describe Decks::CreateReverse do
   def source_deck(cards: [{ front: "明白", back: "understand;clear" }])
-    deck = create(:deck)
+    deck = create(:reading_deck)
     cards.each { |attrs| create(:card, deck:, **attrs) }
     deck
   end
 
   describe ".call" do
-    it "creates a ReverseTextDeck" do
+    it "creates a WritingDeck" do
       result = described_class.call(source: source_deck)
 
-      expect(result.record).to be_a(ReverseTextDeck)
+      expect(result.record).to be_a(WritingDeck)
     end
 
     it "shares the source data_set" do
@@ -24,7 +24,7 @@ RSpec.describe Decks::CreateReverse do
     end
 
     it "names it after the source" do
-      source = create(:deck, name: "HSK 1")
+      source = create(:reading_deck, name: "HSK 1")
       create(:card, deck: source)
       result = described_class.call(source:)
 
@@ -60,6 +60,12 @@ RSpec.describe Decks::CreateReverse do
 
     it "fails when the source is not reversible" do
       result = described_class.call(source: create(:music_deck))
+
+      expect(result).not_to be_success
+    end
+
+    it "fails when the source is a basic deck" do
+      result = described_class.call(source: create(:deck))
 
       expect(result).not_to be_success
     end

--- a/spec/actions/decks/create_spec.rb
+++ b/spec/actions/decks/create_spec.rb
@@ -142,12 +142,29 @@ RSpec.describe Decks::Create do
         expect(deck.data_set).to be_a(LanguageDataSet)
       end
 
+      it "builds a ReadingDeck when a language is given" do
+        user = create(:user)
+        csv = csv_file("front,back\n明白,understand\n")
+        deck = described_class
+          .call(user:, name: "T", cards_csv: csv, language: "zh").record
+
+        expect(deck).to be_a(ReadingDeck)
+      end
+
       it "builds a BasicDataSet without a language" do
         user = create(:user)
         csv = csv_file("front,back\nQ,A\n")
         deck = described_class.call(user:, name: "T", cards_csv: csv).record
 
         expect(deck.data_set).to be_a(BasicDataSet)
+      end
+
+      it "builds a BasicDeck without a language" do
+        user = create(:user)
+        csv = csv_file("front,back\nQ,A\n")
+        deck = described_class.call(user:, name: "T", cards_csv: csv).record
+
+        expect(deck).to be_a(BasicDeck)
       end
     end
 

--- a/spec/domain/study_spec.rb
+++ b/spec/domain/study_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Study do
       end
 
       def reverse_deck_with_reading
-        source = create(:deck)
+        source = create(:reading_deck)
         create(:card, deck: source, front: "两", back: "two", reading: "liǎng")
         reverse = Decks::CreateReverse.call(source:).record
         reverse.tap { |deck| deck.update!(level: Study::READING_LEVEL) }

--- a/spec/factories/decks.rb
+++ b/spec/factories/decks.rb
@@ -1,20 +1,37 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory(:deck, class: "TextDeck") do
+  factory(:deck, class: "BasicDeck") do
     transient do
       sequence(:name, 100) { |n| "Deck #{n}" }
       user { default_user }
-      language { nil }
     end
 
-    data_set do
-      if language
-        association(:language_data_set, user:, name:, language:)
-      else
-        association(:data_set, user:, name:)
-      end
+    data_set { association(:data_set, user:, name:) }
+    study_goal { 50 }
+    distractor_pool { "category" }
+  end
+
+  factory(:reading_deck, class: "ReadingDeck") do
+    transient do
+      sequence(:name, 100) { |n| "Reading Deck #{n}" }
+      user { default_user }
+      language { "zh" }
     end
+
+    data_set { association(:language_data_set, user:, name:, language:) }
+    study_goal { 50 }
+    distractor_pool { "category" }
+  end
+
+  factory(:writing_deck, class: "WritingDeck") do
+    transient do
+      sequence(:name, 100) { |n| "Writing Deck #{n}" }
+      user { default_user }
+      language { "zh" }
+    end
+
+    data_set { association(:language_data_set, user:, name:, language:) }
     study_goal { 50 }
     distractor_pool { "category" }
   end

--- a/spec/models/basic_data_set_spec.rb
+++ b/spec/models/basic_data_set_spec.rb
@@ -6,4 +6,8 @@ RSpec.describe BasicDataSet do
   it "forbids a language" do
     expect(described_class.new).not_to allow_value("zh").for(:language)
   end
+
+  it "builds basic decks" do
+    expect(described_class.new.deck_classes).to contain_exactly(BasicDeck)
+  end
 end

--- a/spec/models/basic_deck_spec.rb
+++ b/spec/models/basic_deck_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BasicDeck do
+  describe ".model_name" do
+    it "returns the Deck model name for routing" do
+      expect(described_class.model_name.route_key).to eq("decks")
+    end
+  end
+end

--- a/spec/models/deck_spec.rb
+++ b/spec/models/deck_spec.rb
@@ -50,12 +50,18 @@ RSpec.describe Deck do
 
   describe "#mandarin?" do
     it "is true when the data_set language is Mandarin" do
-      deck = create(:deck, language: "zh")
+      deck = create(:reading_deck, language: "zh")
 
       expect(deck.mandarin?).to be(true)
     end
 
-    it "is false when the data_set has no language" do
+    it "is false when the language is not Mandarin" do
+      deck = create(:reading_deck, language: "es")
+
+      expect(deck.mandarin?).to be(false)
+    end
+
+    it "is false for a basic deck" do
       deck = create(:deck)
 
       expect(deck.mandarin?).to be(false)
@@ -64,7 +70,7 @@ RSpec.describe Deck do
 
   describe "#hanzi_chars" do
     it "collects the distinct Han characters across items" do
-      deck = create(:deck)
+      deck = create(:reading_deck)
       create(:card, deck:, front: "你好", back: "hello")
       create(:card, deck:, front: "好吗", back: "well?")
 
@@ -72,10 +78,24 @@ RSpec.describe Deck do
     end
 
     it "is empty when no item contains Han characters" do
-      deck = create(:deck)
+      deck = create(:reading_deck, language: "es")
       create(:card, deck:, front: "hola", back: "hello")
 
       expect(deck.hanzi_chars).to eq("")
+    end
+  end
+
+  describe "#type_allowed_by_data_set" do
+    it "rejects a deck class the data_set can't build" do
+      deck = build(:deck, data_set: create(:language_data_set))
+
+      expect(deck).not_to be_valid
+    end
+
+    it "accepts a deck class the data_set can build" do
+      deck = build(:reading_deck)
+
+      expect(deck).to be_valid
     end
   end
 
@@ -148,12 +168,20 @@ RSpec.describe Deck do
   end
 
   describe "#reversible?" do
-    it "is false for the base deck" do
-      expect(described_class.new.reversible?).to be(false)
+    it "is false for a basic deck" do
+      expect(create(:deck).reversible?).to be(false)
     end
 
-    it "is true for a text deck" do
-      expect(create(:deck).reversible?).to be(true)
+    it "is true for a reading deck" do
+      expect(create(:reading_deck).reversible?).to be(true)
+    end
+
+    it "is false for a writing deck" do
+      reading = create(:reading_deck)
+      create(:card, deck: reading)
+      writing = Decks::CreateReverse.call(source: reading).record
+
+      expect(writing.reversible?).to be(false)
     end
   end
 
@@ -163,14 +191,14 @@ RSpec.describe Deck do
     end
 
     it "is false when no reverse deck shares the data_set" do
-      deck = create(:deck)
+      deck = create(:reading_deck)
       create(:card, deck:)
 
       expect(deck.reverse_present?).to be(false)
     end
 
     it "is true when a reverse deck shares the data_set" do
-      deck = create(:deck)
+      deck = create(:reading_deck)
       create(:card, deck:)
       Decks::CreateReverse.call(source: deck)
 

--- a/spec/models/language_data_set_spec.rb
+++ b/spec/models/language_data_set_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe LanguageDataSet do
       .not_to allow_value("xx", "zho", "Spanish").for(:language)
   end
 
+  it "builds reading and writing decks" do
+    expect(described_class.new.deck_classes)
+      .to contain_exactly(ReadingDeck, WritingDeck)
+  end
+
   describe "LANGUAGES" do
     it "keys each language by its shortest available code" do
       expect(described_class::LANGUAGES["zh"]).to eq("Chinese")

--- a/spec/models/language_deck_spec.rb
+++ b/spec/models/language_deck_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LanguageDeck do
+  describe ".model_name" do
+    it "returns the Deck model name for routing" do
+      expect(described_class.model_name.route_key).to eq("decks")
+    end
+  end
+end

--- a/spec/models/music_data_set_spec.rb
+++ b/spec/models/music_data_set_spec.rb
@@ -6,4 +6,8 @@ RSpec.describe MusicDataSet do
   it "forbids a language" do
     expect(described_class.new).not_to allow_value("zh").for(:language)
   end
+
+  it "builds music decks" do
+    expect(described_class.new.deck_classes).to contain_exactly(MusicDeck)
+  end
 end

--- a/spec/models/reverse_text_card_spec.rb
+++ b/spec/models/reverse_text_card_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ReverseTextCard do
   # Reverse a forward deck holding a single (single-gloss) card and return its
   # one reverse card.
   def reverse_card(**forward)
-    deck = create(:deck)
+    deck = create(:reading_deck)
     create(:card, deck:, **forward)
     Decks::CreateReverse.call(source: deck).record.cards.sole
   end
@@ -21,7 +21,7 @@ RSpec.describe ReverseTextCard do
   end
 
   it "joins multiple paired fronts as the answer" do
-    deck = create(:deck)
+    deck = create(:reading_deck)
     create(:card, deck:, front: "明白", back: "understand")
     create(:card, deck:, front: "清楚", back: "understand")
     rev = Decks::CreateReverse.call(source: deck).record

--- a/spec/models/writing_deck_spec.rb
+++ b/spec/models/writing_deck_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ReverseTextDeck do
+RSpec.describe WritingDeck do
   it "anchors the Back side" do
     expect(described_class.new.anchor_side).to eq("Back")
   end
@@ -21,7 +21,7 @@ RSpec.describe ReverseTextDeck do
 
   describe "#cards_in_category" do
     def reverse_with_categories
-      fwd = create(:deck)
+      fwd = create(:reading_deck)
       create(:card, deck: fwd, front: "明白", back: "know", category: "v")
       create(:card, deck: fwd, front: "你好", back: "hi", category: "g")
       Decks::CreateReverse.call(source: fwd).record

--- a/spec/requests/decks_controller_spec.rb
+++ b/spec/requests/decks_controller_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe DecksController do
     end
 
     def deck_with_card
-      create(:card, deck: create(:deck)).deck
+      create(:card, deck: create(:reading_deck)).deck
     end
 
     it "shows the create-reverse button for a forward deck" do
@@ -441,6 +441,20 @@ RSpec.describe DecksController do
         expect(DataSet.find_by(name: "Vocab")).to be_a(LanguageDataSet)
       end
 
+      it "creates a ReadingDeck" do
+        post_language_deck(language: "es")
+
+        expect(DataSet.find_by(name: "Vocab").decks.sole).to be_a(ReadingDeck)
+      end
+
+      it "re-renders the form when a language deck fails validation" do
+        create(:data_set, name: "Vocab", user: default_user)
+
+        post_language_deck(language: "es")
+
+        expect(rendered).to have_text("Create New Deck")
+      end
+
       it "re-renders the form when no language is selected" do
         post_language_deck
 
@@ -472,8 +486,8 @@ RSpec.describe DecksController do
         expect { post_music_deck }.to change(MusicDeck, :count).by(1)
       end
 
-      it "does not create a TextDeck" do
-        expect { post_music_deck }.not_to change(TextDeck, :count)
+      it "does not create a BasicDeck" do
+        expect { post_music_deck }.not_to change(BasicDeck, :count)
       end
 
       it "redirects to decks index" do

--- a/spec/requests/reversals_controller_spec.rb
+++ b/spec/requests/reversals_controller_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ReversalsController do
   def reversible_deck
-    deck = create(:deck, user: default_user)
+    deck = create(:reading_deck, user: default_user)
     create(:card, deck:)
     deck
   end
@@ -19,7 +19,7 @@ RSpec.describe ReversalsController do
       login_as(default_user)
 
       expect { post(deck_reversal_path(deck)) }
-        .to change(ReverseTextDeck, :count).by(1)
+        .to change(WritingDeck, :count).by(1)
     end
 
     it "redirects to the new reverse deck" do
@@ -28,7 +28,7 @@ RSpec.describe ReversalsController do
 
       post(deck_reversal_path(deck))
 
-      expect(response).to redirect_to(deck_path(ReverseTextDeck.last))
+      expect(response).to redirect_to(deck_path(WritingDeck.last))
     end
 
     it "sets a success flash" do

--- a/spec/requests/studies_controller_spec.rb
+++ b/spec/requests/studies_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe StudiesController do
     end
 
     it "wires the font controller on a Mandarin deck", :aggregate_failures do
-      deck = create(:deck, language: "zh")
+      deck = create(:reading_deck)
       create(:card, deck:, front: "他", back: "he; him")
       get(deck_study_path(deck))
 
@@ -64,7 +64,7 @@ RSpec.describe StudiesController do
     end
 
     it "embeds the deck's hanzi for font prewarming on full page loads" do
-      deck = create(:deck, language: "zh")
+      deck = create(:reading_deck)
       create(:card, deck:, front: "他", back: "he; him")
       get(deck_study_path(deck))
 
@@ -72,7 +72,7 @@ RSpec.describe StudiesController do
     end
 
     it "omits the hanzi payload on turbo frame navigations" do
-      deck = create(:deck, language: "zh")
+      deck = create(:reading_deck)
       create(:card, deck:, front: "他", back: "he; him")
       get(deck_study_path(deck), headers: { "Turbo-Frame" => "study" })
 

--- a/spec/system/font_spec.rb
+++ b/spec/system/font_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "study font" do
   end
 
   def visit_hanzi_study_page
-    deck = create(:deck, user: default_user, language: "zh")
+    deck = create(:reading_deck, user: default_user)
     hanzi_cards.each { |front, back| create(:card, deck:, front:, back:) }
     sign_in(default_user)
     visit(deck_study_path(deck))

--- a/spec/system/music_decks_spec.rb
+++ b/spec/system/music_decks_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "creating a music deck" do
     visit_new_deck
     submit_text_form(name: "Basic")
 
-    expect(TextDeck.joins(:data_set).find_by(data_sets: { name: "Basic" }))
+    expect(BasicDeck.joins(:data_set).find_by(data_sets: { name: "Basic" }))
       .to be_present
   end
 end

--- a/spec/system/reverse_decks_spec.rb
+++ b/spec/system/reverse_decks_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "reverse decks" do
   def forward_deck
-    deck = create(:deck, name: "Mandarin", user: default_user)
+    deck = create(:reading_deck, name: "Mandarin", user: default_user)
     create(:card, deck:, front: "明白", back: "understand")
     deck
   end
@@ -32,7 +32,7 @@ RSpec.describe "reverse decks" do
 
   it "can be studied with the back as the prompt" do
     reversed_source
-    visit(deck_study_path(ReverseTextDeck.last))
+    visit(deck_study_path(WritingDeck.last))
 
     expect(page).to have_text("understand")
   end


### PR DESCRIPTION
**What**

This introduces new and renames some Deck classes.

**Why**

This will allow them to be fit more for purpose. In particular, language
decks will map more closely to their actual usage.
