### PR TITLE
Decks: record when a deck was last studied

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -14,6 +14,7 @@ class StudiesController < ApplicationController
   def update
     deck = current_user.decks.find(params.expect(:deck_id))
     result = Study.for(deck:).record_answer(params)
+    deck.update!(last_studied_at: Time.current)
     increment_counters(result)
     if result.reading_passed?
       render_translation_stage(deck, result.card)

--- a/db/migrate/20260712000001_add_last_studied_at_to_decks.rb
+++ b/db/migrate/20260712000001_add_last_studied_at_to_decks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastStudiedAtToDecks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :decks, :last_studied_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -59,6 +59,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_000000) do
     t.datetime "created_at", null: false
     t.bigint "data_set_id", null: false
     t.string "distractor_pool", null: false
+    t.datetime "last_studied_at"
     t.integer "level", null: false
     t.boolean "ordered", default: false, null: false
     t.string "share_token"

--- a/spec/requests/studies_controller_spec.rb
+++ b/spec/requests/studies_controller_spec.rb
@@ -289,6 +289,22 @@ RSpec.describe StudiesController do
       end
     end
 
+    it "stamps the deck's last studied time" do
+      card = create(:basic_card, back: "Paris")
+      create(:basic_card, deck: card.deck)
+
+      expect { submit_answer(card:, answer: "Paris") }
+        .to change_record(card.deck, :last_studied_at).from(nil)
+    end
+
+    it "stamps the deck's last studied time on an incorrect answer" do
+      card = create(:basic_card, back: "Paris")
+      create(:basic_card, deck: card.deck)
+
+      expect { submit_answer(card:, answer: "London") }
+        .to change_record(card.deck, :last_studied_at).from(nil)
+    end
+
     it "shows level complete screen when last card is answered" do
       card = create(:basic_card, back: "Paris", correct_streak: 0)
       submit_answer(card:, answer: "Paris")
@@ -460,6 +476,14 @@ RSpec.describe StudiesController do
 
       expect(rendered)
         .to have_css("[data-music-study-sequence-value='C4,E4,G4']")
+    end
+
+    it "stamps the deck's last studied time" do
+      deck = music_deck
+      seed_notes(deck, ["C4", "E4"])
+
+      expect { submit_music_window(deck, answer: "C4") }
+        .to change_record(deck, :last_studied_at).from(nil)
     end
 
     it "renders the music-result UI after a correct answer" do


### PR DESCRIPTION
Adds a nullable `last_studied_at` timestamp to `decks`, stamped in `StudiesController#update` on every recorded answer. The stamp lives in the controller because it is the single entry point for both study kinds — `MusicStudy` overrides `record_answer`, so stamping inside `Study` would miss music decks.

This is PR 1 of the topic-rail redesign of the decks index: the timestamp will drive the "most recently used" spotlight card at the left of each topic's rail.

No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dei5dBe9sML3yABXT1B6Ar