### PR TITLE
Organization: show decks within a topic as a horizontal list

### DIFF
--- a/app/assets/stylesheets/decks.css
+++ b/app/assets/stylesheets/decks.css
@@ -39,14 +39,6 @@
   gap: 0.75rem;
 }
 
-/* Decks Grid */
-.decks-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-  gap: 2rem;
-  animation: gridFadeIn 0.5s ease-out;
-}
-
 .decks-section-title {
   font-family: var(--font-display);
   font-size: clamp(20px, 3vw, 26px);
@@ -55,59 +47,174 @@
   margin: 2rem 0 1rem;
 }
 
-.decks-grid + .decks-section-title {
-  margin-top: 3rem;
+.topic-meta {
+  margin-left: 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-muted);
 }
 
-@keyframes gridFadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
+.rail {
+  display: flex;
+  gap: 0.9rem;
+  padding: 4px 4px 14px;
+  overflow-x: auto;
+  scroll-snap-type: x proximity;
+}
+
+.rail::-webkit-scrollbar {
+  height: 8px;
+}
+
+.rail::-webkit-scrollbar-track {
+  background: var(--color-background-subtle);
+}
+
+.rail::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+}
+
+.rail-card {
+  position: relative;
+  display: flex;
+  flex: 0 0 210px;
+  flex-direction: column;
+  padding: 0.85rem 1rem 0.9rem;
+  background: var(--color-background-elevated);
+  border: 3px solid var(--color-border);
+  box-shadow: 4px 4px 0 -1px var(--color-background), 4px 4px 0 0 var(--color-border-medium);
+  scroll-snap-align: start;
+}
+
+.rail-card--mru {
+  flex-basis: 220px;
+  border-color: var(--color-primary);
+  box-shadow: 4px 4px 0 -1px var(--color-background), 4px 4px 0 0 var(--color-primary-dark);
+}
+
+.rail-card--mru::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 5px;
+  background: var(--stripe-small);
+}
+
+.rail-card--set-start {
+  margin-left: 0.9rem;
+}
+
+.rail-divider {
+  flex: 0 0 3px;
+  align-self: stretch;
+  margin: 2px 0.35rem;
+  background: var(--color-border);
+}
+
+.mru-label {
+  margin: 0.2rem 0 0.35rem;
+  padding-right: 3.2rem;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.7px;
+  color: var(--color-primary);
+  text-transform: uppercase;
+}
+
+.rail-type {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.7px;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+}
+
+.rail-title {
+  margin: 0.05rem 0 0.2rem;
+  overflow: hidden;
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.3;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.rail-title a,
+.rail-title a:visited {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.rail-title a:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+  background: none;
+}
+
+.rail-stars {
+  display: flex;
+  gap: 2px;
+}
+
+.rail-stars .star {
+  font-size: 1.125rem;
+}
+
+.rail-meta {
+  display: flex;
+  gap: 0.4rem;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-top: auto;
+  padding-top: 0.45rem;
+}
+
+.rail-remaining {
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.rail-remaining--done {
+  color: var(--color-success-dark);
+}
+
+.rail-remaining--empty {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.rail-card-study,
+.rail-card-study:visited {
+  position: absolute;
+  top: 0.7rem;
+  right: 0.85rem;
+  font-size: 13.5px;
+  font-weight: 800;
+  color: var(--color-secondary);
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.rail-card-study:focus-visible,
+.rail-card:hover .rail-card-study {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .rail-card-study {
     opacity: 1;
   }
-}
-
-.deck-card {
-  padding: 1.75rem;
-  overflow: hidden;
-  box-shadow: var(--shadow-small);
-  transition: all var(--transition);
-  animation: fade-in-up 0.4s ease-out backwards;
-}
-
-.deck-card:nth-child(1) { animation-delay: 0ms; }
-.deck-card:nth-child(2) { animation-delay: 50ms; }
-.deck-card:nth-child(3) { animation-delay: 100ms; }
-.deck-card:nth-child(4) { animation-delay: 150ms; }
-.deck-card:nth-child(5) { animation-delay: 200ms; }
-.deck-card:nth-child(6) { animation-delay: 250ms; }
-
-.deck-card:hover {
-  transform: translate(-2px, -2px);
-  border-color: var(--color-border-medium);
-  box-shadow: var(--shadow-hover);
-}
-
-.deck-card-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-  padding-bottom: 1.25rem;
-  border-bottom: 2px solid var(--color-background-subtle);
-}
-
-.deck-card-title {
-  font-family: var(--font-display);
-  font-size: 1.5rem;
-  font-weight: 400;
-  color: var(--color-text);
-  margin: 0;
-  flex: 1;
-  line-height: 1.3;
-  word-break: break-word;
 }
 
 .count-number {
@@ -128,102 +235,7 @@
   margin-top: 0.25rem;
 }
 
-/* Deck Stats */
-.deck-stats {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.stat-item {
-  padding: 1rem 0.75rem;
-  background: var(--color-background-subtle);
-  border-left: 4px solid;
-  text-align: center;
-  transition: all var(--transition);
-}
-
-.stat-item:hover {
-  transform: translateX(2px);
-  background: var(--color-background-hover);
-}
-
-.stat-level {
-  border-color: var(--color-accent);
-}
-
-.deck-card-stars {
-  display: flex;
-  gap: 2px;
-  margin-top: 0.25rem;
-}
-
-.deck-card-stars .star {
-  font-size: 1.25rem;
-}
-
-.stat-pending {
-  border-color: var(--color-text-muted);
-}
-
-.stat-active {
-  border-color: var(--color-accent);
-}
-
-.stat-done {
-  border-color: var(--color-success-border);
-}
-
-.stat-value {
-  font-family: var(--font-display);
-  font-size: 1.875rem;
-  font-weight: 400;
-  color: var(--color-text);
-  line-height: 1;
-  margin-bottom: 0.375rem;
-}
-
-.stat-label {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.deck-empty-message {
-  padding: 2rem 1rem;
-  text-align: center;
-  font-family: var(--font-body);
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--color-border-medium);
-  font-style: italic;
-  background: var(--color-background-subtle);
-  border: 2px dashed var(--color-border);
-  margin-bottom: 1.5rem;
-}
-
-/* Deck Card Actions */
-.deck-card-actions {
-  display: flex;
-  gap: 0.75rem;
-}
-
-.deck-card-actions .button {
-  flex: 1;
-}
-
 /* Responsive Design */
-@media (max-width: 1024px) {
-  .decks-grid {
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 1.5rem;
-  }
-}
-
 @media (max-width: 768px) {
   .decks-container {
     padding: 1.5rem 1rem 3rem;
@@ -242,32 +254,6 @@
   .decks-header-actions {
     flex-direction: column;
   }
-
-  .decks-grid {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-  }
-
-  .deck-card {
-    padding: 1.5rem;
-  }
-
-  .deck-stats {
-    gap: 0.75rem;
-  }
-
-  .stat-item {
-    padding: 0.875rem 0.625rem;
-  }
-
-  .stat-value {
-    font-size: 1.5rem;
-  }
-
-  .deck-card-actions {
-    flex-direction: column;
-  }
-
 }
 
 
@@ -737,6 +723,12 @@
   color: var(--color-primary);
   background: rgb(var(--color-primary-channels) / 12%);
   border-radius: 0.375rem;
+}
+
+.rail-meta .deck-suggestion-badge {
+  margin-top: 0;
+  padding: 0.1rem 0.45rem;
+  font-size: 11px;
 }
 
 .deck-suggestion-badge:hover {

--- a/app/models/basic_deck.rb
+++ b/app/models/basic_deck.rb
@@ -9,5 +9,7 @@ class BasicDeck < Deck
 
   def card_type = "BasicCard"
 
+  def type_label = "Basic"
+
   def replaceable? = true
 end

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -25,6 +25,10 @@ class Deck < ApplicationRecord
 
   def music? = false
 
+  # Where the deck sorts among its data_set's siblings on the decks index
+  # rail; forward study comes first, so only reverse decks push later.
+  def type_position = 1
+
   # The item side a deck's cards anchor to (and study as the prompt). A reverse
   # deck flips this to "Back"; the projection reconciles each deck's cards to
   # the paired items on its anchor side.

--- a/app/models/music_deck.rb
+++ b/app/models/music_deck.rb
@@ -11,6 +11,8 @@ class MusicDeck < Deck
 
   def card_type = "MusicCard"
 
+  def type_label = "Practice"
+
   private
 
   def default_distractor_pool

--- a/app/models/reading_deck.rb
+++ b/app/models/reading_deck.rb
@@ -5,6 +5,8 @@
 class ReadingDeck < LanguageDeck
   def card_type = "ReadingCard"
 
+  def type_label = "Reading"
+
   def reversible? = true
 
   def replaceable? = true

--- a/app/models/writing_deck.rb
+++ b/app/models/writing_deck.rb
@@ -9,6 +9,10 @@ class WritingDeck < LanguageDeck
 
   def card_type = "WritingCard"
 
+  def type_label = "Writing"
+
+  def type_position = 2
+
   def anchor_side = "Back"
 
   def anchor_pairing_column = :paired_item_id

--- a/app/views/decks/index.rb
+++ b/app/views/decks/index.rb
@@ -3,6 +3,8 @@
 module Views
   module Decks
     class Index < Views::Base
+      include Phlex::Rails::Helpers::TimeAgoInWords
+
       attr_accessor :decks, :pending_counts, :filter_pending
 
       def initialize(decks:, pending_counts:, filter_pending:)
@@ -75,81 +77,110 @@ module Views
         topics = grouped.keys.compact.sort_by(&:name)
         loose = grouped[nil] || []
 
-        topics.each { |topic| render_topic_section(topic, grouped[topic]) }
+        topics.each { |topic| render_topic_section(topic.name, grouped[topic]) }
         return if loose.empty?
 
-        h2(class: "decks-section-title") { "Other Decks" } if topics.any?
-        render_decks_grid(loose)
+        render_topic_section(topics.any? ? "Other Decks" : nil, loose)
       end
 
-      def render_topic_section(topic, topic_decks)
-        h2(class: "decks-section-title") { topic.name }
-        render_decks_grid(topic_decks)
+      def render_topic_section(title, section_decks)
+        section(class: "topic-section") do
+          render_section_heading(title, section_decks) if title
+          render_rail(section_decks)
+        end
       end
 
-      def render_decks_grid(section_decks)
-        div(class: "decks-grid") do
-          section_decks.each do |deck|
-            render_deck_card(deck)
+      def render_section_heading(title, section_decks)
+        h2(class: "decks-section-title") do
+          plain(title)
+          span(class: "topic-meta") do
+            pluralize(section_decks.size, "deck")
           end
         end
       end
 
-      def render_deck_card(deck)
-        div(class: "card card--striped deck-card") do
-          render_deck_card_header(deck)
+      # The most recently studied deck repeats at the head of the rail as a
+      # spotlight; the copy in its natural slot stays put so the list order
+      # never shifts underneath the reader.
+      def render_rail(section_decks)
+        div(class: "rail") do
+          render_mru_spotlight(section_decks)
 
-          if deck.cards.any?
-            render_deck_stats(deck)
-          else
-            div(class: "deck-empty-message") do
-              "No cards yet"
+          deck_sets(section_decks).each_with_index do |set_decks, set_index|
+            set_decks.each_with_index do |deck, deck_index|
+              set_start = set_index.positive? && deck_index.zero?
+              render_rail_card(deck, set_start:)
             end
           end
-
-          div(class: "deck-card-actions") do
-            link_to("Study", deck_study_path(deck), class: button_class(:secondary, :compact))
-            link_to("View Details", deck_path(deck), class: button_class(:ghost, :compact))
-          end
         end
       end
 
-      def render_deck_card_header(deck)
-        div(class: "deck-card-header") do
-          div do
-            h3(class: "deck-card-title") do
-              plain(deck.name)
-              catalog_badge if deck.publicly_visible?
-            end
-            render_stars(deck.level - 1)
-            render_suggestion_badge(deck) if pending_counts[deck.id]&.positive?
-          end
-          div(class: "card-count") do
-            span(class: "count-number") { deck.cards.count }
-            span(class: "count-label") { "cards" }
-          end
+      def deck_sets(section_decks)
+        section_decks
+          .sort_by { |deck| [deck.data_set.name, deck.type_position] }
+          .chunk_while { |a, b| a.data_set_id == b.data_set_id }
+      end
+
+      def render_mru_spotlight(section_decks)
+        mru = section_decks.select(&:last_studied_at).max_by(&:last_studied_at)
+        return if mru.nil?
+
+        render_rail_card(mru, mru: true)
+        div(class: "rail-divider")
+      end
+
+      def render_rail_card(deck, mru: false, set_start: false)
+        classes = [
+          "rail-card",
+          ("rail-card--mru" if mru),
+          ("rail-card--set-start" if set_start),
+        ].compact.join(" ")
+
+        div(class: classes) do
+          remaining = deck.cards.not_done(deck.level).count
+          render_study_link(deck, remaining)
+          render_mru_label(deck) if mru
+          div(class: "rail-type") { deck.type_label }
+          render_rail_title(deck)
+          render_stars(deck.level - 1)
+          render_rail_meta(deck, remaining)
         end
       end
 
-      def render_deck_stats(deck)
-        not_done_count = deck.cards.not_done(deck.level).count
-        done_count = deck.cards.done(deck.level).count
+      def render_study_link(deck, remaining)
+        return if deck.cards.none?
 
-        div(class: "deck-stats") do
-          div(class: "stat-item stat-level") do
-            div(class: "stat-value") { deck.level }
-            div(class: "stat-label") { "Level" }
-          end
+        label = remaining.zero? ? "Review →" : "Study →"
+        link_to(label, deck_study_path(deck), class: "rail-card-study")
+      end
 
-          div(class: "stat-item stat-pending") do
-            div(class: "stat-value") { not_done_count }
-            div(class: "stat-label") { "Remaining" }
-          end
+      def render_mru_label(deck)
+        div(class: "mru-label") do
+          "↻ Last studied #{time_ago_in_words(deck.last_studied_at)} ago"
+        end
+      end
 
-          div(class: "stat-item stat-done") do
-            div(class: "stat-value") { done_count }
-            div(class: "stat-label") { "Done" }
-          end
+      def render_rail_title(deck)
+        h3(class: "rail-title") do
+          link_to(deck.data_set.name, deck_path(deck))
+          catalog_badge if deck.publicly_visible?
+        end
+      end
+
+      def render_rail_meta(deck, remaining)
+        div(class: "rail-meta") do
+          render_remaining(deck, remaining)
+          render_suggestion_badge(deck) if pending_counts[deck.id]&.positive?
+        end
+      end
+
+      def render_remaining(deck, remaining)
+        if deck.cards.none?
+          span(class: "rail-remaining rail-remaining--empty") { "No cards yet" }
+        elsif remaining.zero?
+          span(class: "rail-remaining rail-remaining--done") { "Done ✓" }
+        else
+          span(class: "rail-remaining") { "#{remaining} left" }
         end
       end
 
@@ -162,7 +193,7 @@ module Views
       end
 
       def render_stars(completed_levels)
-        div(class: "deck-card-stars") do
+        div(class: "rail-stars") do
           3.times do |i|
             css = i < completed_levels ? "star star--filled" : "star star--empty"
             span(class: css) { "★" }

--- a/spec/models/basic_deck_spec.rb
+++ b/spec/models/basic_deck_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe BasicDeck do
     expect(described_class.new.card_type).to eq("BasicCard")
   end
 
+  it "is labeled Basic on the decks index" do
+    expect(described_class.new.type_label).to eq("Basic")
+  end
+
   describe ".model_name" do
     it "returns the Deck model name for routing" do
       expect(described_class.model_name.route_key).to eq("decks")

--- a/spec/models/music_deck_spec.rb
+++ b/spec/models/music_deck_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe MusicDeck do
     end
   end
 
+  it "is labeled Practice on the decks index" do
+    expect(described_class.new.type_label).to eq("Practice")
+  end
+
   describe "#distractor_pool" do
     it "defaults to 'none'" do
       expect(described_class.new.distractor_pool).to eq("none")

--- a/spec/models/reading_deck_spec.rb
+++ b/spec/models/reading_deck_spec.rb
@@ -6,4 +6,12 @@ RSpec.describe ReadingDeck do
   it "builds ReadingCards" do
     expect(described_class.new.card_type).to eq("ReadingCard")
   end
+
+  it "is labeled Reading on the decks index" do
+    expect(described_class.new.type_label).to eq("Reading")
+  end
+
+  it "sorts first among its set's decks" do
+    expect(described_class.new.type_position).to eq(1)
+  end
 end

--- a/spec/models/writing_deck_spec.rb
+++ b/spec/models/writing_deck_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe WritingDeck do
     expect(described_class.new.card_type).to eq("WritingCard")
   end
 
+  it "is labeled Writing on the decks index" do
+    expect(described_class.new.type_label).to eq("Writing")
+  end
+
+  it "sorts after its set's forward deck" do
+    expect(described_class.new.type_position).to eq(2)
+  end
+
   it "is not itself reversible" do
     expect(described_class.new.reversible?).to be(false)
   end

--- a/spec/requests/decks_controller_spec.rb
+++ b/spec/requests/decks_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DecksController do
       expect(rendered).to have_text("No Decks Yet")
     end
 
-    it "renders decks grid when user has decks" do
+    it "renders the deck rail when user has decks" do
       login_as(default_user)
       create(:deck, user: default_user, name: "My Test Deck")
 
@@ -54,14 +54,13 @@ RSpec.describe DecksController do
       expect(rendered).to have_no_css("h2", text: "Other Decks")
     end
 
-    it "shows card count for each deck" do
+    it "shows the deck count in a topic heading" do
       login_as(default_user)
-      deck = create(:deck, user: default_user)
-      create(:basic_card, deck:)
+      deck_in_topic("Mandarin")
 
       get(decks_path)
 
-      expect(rendered).to have_text("1")
+      expect(rendered).to have_css(".topic-meta", text: "1 deck")
     end
 
     it "shows 'No cards yet' for empty deck" do
@@ -73,14 +72,146 @@ RSpec.describe DecksController do
       expect(rendered).to have_text("No cards yet")
     end
 
-    it "shows stats for deck with cards" do
+    it "shows the remaining count for a deck with cards" do
       deck = create(:deck, user: default_user)
       create(:basic_card, deck:)
       login_as(default_user)
 
       get(decks_path)
 
-      expect(rendered).to have_text("Remaining")
+      expect(rendered).to have_text("1 left")
+    end
+
+    it "labels each deck with its type" do
+      login_as(default_user)
+      create(:deck, user: default_user)
+
+      get(decks_path)
+
+      expect(rendered).to have_css(".rail-type", text: "Basic")
+    end
+
+    it "links the deck name to the deck page" do
+      deck = create(:deck, user: default_user)
+      login_as(default_user)
+
+      get(decks_path)
+
+      expect(rendered).to have_link(deck.name, href: deck_path(deck))
+    end
+
+    it "links each deck with pending cards to its study page" do
+      deck = create(:deck, user: default_user)
+      create(:basic_card, deck:)
+      login_as(default_user)
+
+      get(decks_path)
+
+      expect(rendered).to have_link("Study →", href: deck_study_path(deck))
+    end
+
+    it "omits the study link for a deck with no cards" do
+      create(:deck, user: default_user)
+      login_as(default_user)
+
+      get(decks_path)
+
+      expect(rendered).to have_no_link("Study →")
+    end
+
+    it "shows Done for a deck whose cards are all done" do
+      deck = create(:deck, user: default_user)
+      create(:basic_card, deck:, correct_streak: 1)
+      login_as(default_user)
+
+      get(decks_path)
+
+      expect(rendered).to have_text("Done ✓")
+    end
+
+    it "offers Review instead of Study when a deck is done" do
+      deck = create(:deck, user: default_user)
+      create(:basic_card, deck:, correct_streak: 1)
+      login_as(default_user)
+
+      get(decks_path)
+
+      expect(rendered).to have_link("Review →", href: deck_study_path(deck))
+    end
+
+    def reversible_pair
+      reading = create(:reading_deck, user: default_user)
+      create(:writing_deck, data_set: reading.data_set)
+    end
+
+    it "orders a reading deck before the writing deck sharing its set" do
+      login_as(default_user)
+      reversible_pair
+
+      get(decks_path)
+
+      expect(rendered)
+        .to have_css(".rail-card:first-child .rail-type", text: "Reading")
+    end
+
+    it "titles a writing deck with its set name, not the reversed name" do
+      login_as(default_user)
+      reversible_pair
+
+      get(decks_path)
+
+      expect(rendered).to have_no_text("(reversed)")
+    end
+
+    def studied_deck(name, at)
+      create(:deck, user: default_user, name:, last_studied_at: at)
+    end
+
+    it "spotlights the most recently studied deck" do
+      login_as(default_user)
+      studied_deck("Old", 2.days.ago)
+      studied_deck("New", 1.hour.ago)
+
+      get(decks_path)
+
+      expect(rendered).to have_css(".rail-card--mru .rail-title", text: "New")
+    end
+
+    it "notes when the spotlighted deck was last studied" do
+      login_as(default_user)
+      create(:deck, user: default_user, last_studied_at: 1.hour.ago)
+
+      get(decks_path)
+
+      expect(rendered).to have_text("Last studied about 1 hour ago")
+    end
+
+    it "keeps the spotlighted deck in its natural position as well" do
+      login_as(default_user)
+      create(:deck, user: default_user, last_studied_at: 1.hour.ago)
+
+      get(decks_path)
+
+      expect(rendered).to have_css(".rail-card", count: 2)
+    end
+
+    it "renders no spotlight when nothing has been studied" do
+      login_as(default_user)
+      create(:deck, user: default_user)
+
+      get(decks_path)
+
+      expect(rendered).to have_no_css(".rail-card--mru")
+    end
+
+    it "spotlights per topic, not across the whole page" do
+      login_as(default_user)
+      deck_in_topic("Mandarin").update!(last_studied_at: 1.hour.ago)
+      deck_in_topic("Music")
+
+      get(decks_path)
+
+      expect(rendered).to have_css(".rail-card--mru", count: 1)
     end
 
     it "shows filled stars for completed levels" do


### PR DESCRIPTION
**What**

This updates our decks/index page to display decks as a horizontally
scrollable list. It allows us to fit more information on the page, which
will be helpful as the number of decks grows.
