### PR TITLE
use scroll snap on mobile only

### DIFF
--- a/app/assets/stylesheets/decks.css
+++ b/app/assets/stylesheets/decks.css
@@ -141,8 +141,13 @@
   gap: 0.9rem;
   padding: 4px 4px 14px;
   overflow-x: auto;
-  scroll-snap-type: x proximity;
   scroll-padding-inline: 4px;
+}
+
+@media (pointer: coarse) {
+  .rail {
+    scroll-snap-type: x proximity;
+  }
 }
 
 .rail::-webkit-scrollbar {


### PR DESCRIPTION
**Why**

Two finger swipe on desktop in Firefox is pretty clunky with this
enabled, so this makes it mobile only.
