### PR TITLE
Flake: increase Capybara wait time

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,6 +7,7 @@ require_relative "capybara/rack_test"
 Capybara.enable_aria_label = true
 Capybara.save_path = ENV.fetch("CIRCLE_ARTIFACTS", Capybara.save_path)
 Capybara.server = :puma, { Silent: true }
+Capybara.default_max_wait_time = Integer(ENV.fetch("CAPYBARA_MAX_WAIT_TIME", 5))
 
 driver = ENV.fetch("DRIVER", :firefox).to_sym
 


### PR DESCRIPTION
**Why**

We're seeing [some flake][fl] that seems related to things taking too long.

[fl]: https://app.circleci.com/pipelines/github/mockdeep/Flash/852/workflows/3f2c6948-d703-4cbf-b8cb-1369c3ecaeb5/jobs/861
