### PR TITLE
Errors: add tzinfo-data gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "puma"
 gem "stimulus-rails"
 gem "strong_migrations"
 gem "turbo-rails"
+gem "tzinfo-data"
 
 group :development, :test do
   gem "bundler-audit", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,6 +385,8 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -448,6 +450,7 @@ DEPENDENCIES
   stimulus-rails
   strong_migrations
   turbo-rails
+  tzinfo-data
   web-console
   webmock
 


### PR DESCRIPTION
**Why**

We got an error where a user's time zone came in as
"America/Buenos_Aires", but Heroku dynos only support it in the format
of "America/Argentina/Buenos_Aires". This makes it so the app supports
both the legacy and the modern time zone format.
